### PR TITLE
feat(github): determine network status based on kubernetes directory presence

### DIFF
--- a/pkg/providers/github/provider_test.go
+++ b/pkg/providers/github/provider_test.go
@@ -2,13 +2,14 @@ package github
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
-	gh "github.com/google/go-github/v53/github"
 	"github.com/ethpandaops/cartographoor/pkg/discovery"
+	gh "github.com/google/go-github/v53/github"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -45,7 +46,7 @@ func TestProvider_Discover(t *testing.T) {
 	config := discovery.Config{
 		GitHub: struct {
 			Repositories []discovery.GitHubRepositoryConfig `mapstructure:"repositories"`
-			Token        string                            `mapstructure:"token"`
+			Token        string                             `mapstructure:"token"`
 		}{
 			Repositories: []discovery.GitHubRepositoryConfig{
 				{
@@ -110,7 +111,7 @@ func TestProvider_DiscoverWithPrefix(t *testing.T) {
 	config := discovery.Config{
 		GitHub: struct {
 			Repositories []discovery.GitHubRepositoryConfig `mapstructure:"repositories"`
-			Token        string                            `mapstructure:"token"`
+			Token        string                             `mapstructure:"token"`
 		}{
 			Repositories: []discovery.GitHubRepositoryConfig{
 				{
@@ -162,7 +163,7 @@ func TestProvider_Discover_NoRepositories(t *testing.T) {
 	config := discovery.Config{
 		GitHub: struct {
 			Repositories []discovery.GitHubRepositoryConfig `mapstructure:"repositories"`
-			Token        string                            `mapstructure:"token"`
+			Token        string                             `mapstructure:"token"`
 		}{
 			Repositories: []discovery.GitHubRepositoryConfig{},
 			Token:        "",
@@ -184,7 +185,7 @@ func TestProvider_Discover_InvalidRepository(t *testing.T) {
 	config := discovery.Config{
 		GitHub: struct {
 			Repositories []discovery.GitHubRepositoryConfig `mapstructure:"repositories"`
-			Token        string                            `mapstructure:"token"`
+			Token        string                             `mapstructure:"token"`
 		}{
 			Repositories: []discovery.GitHubRepositoryConfig{
 				{
@@ -201,6 +202,62 @@ func TestProvider_Discover_InvalidRepository(t *testing.T) {
 	// Should not error, just log a warning and return empty networks
 }
 
+func TestProvider_DiscoverNetworkStatus(t *testing.T) {
+	log := logrus.New()
+	log.SetLevel(logrus.DebugLevel)
+
+	// Mock GitHub API server
+	ts := mockGitHubAPIWithStatus(t)
+	defer ts.Close()
+
+	provider, err := NewProvider(log)
+	require.NoError(t, err)
+
+	// Create a custom GitHub client that uses our test server
+	httpClient := &http.Client{
+		Transport: &mockTransport{URL: ts.URL},
+	}
+	provider.client = gh.NewClient(httpClient)
+
+	// Configure discovery
+	config := discovery.Config{
+		GitHub: struct {
+			Repositories []discovery.GitHubRepositoryConfig `mapstructure:"repositories"`
+			Token        string                             `mapstructure:"token"`
+		}{
+			Repositories: []discovery.GitHubRepositoryConfig{
+				{
+					Name:       "ethpandaops/pectra-devnets",
+					NamePrefix: "",
+				},
+			},
+			Token: "",
+		},
+	}
+
+	// Test discovery
+	networks, err := provider.Discover(context.Background(), config)
+	require.NoError(t, err)
+
+	// Validate the discovered networks
+	require.Len(t, networks, 3)
+
+	// Check status for each network
+	expected := map[string]string{
+		"devnet-active":   "active",   // exists in kubernetes/
+		"devnet-inactive": "inactive", // exists in kubernetes-archive/
+		"devnet-unknown":  "unknown",  // doesn't exist in either
+	}
+
+	for networkName, expectedStatus := range expected {
+		network, exists := networks[networkName]
+		assert.True(t, exists, "Network %s should exist", networkName)
+		if exists {
+			assert.Equal(t, expectedStatus, network.Status, "Network %s should have status %s", networkName, expectedStatus)
+		}
+	}
+}
+
 // Mock HTTP transport to redirect GitHub API requests to our test server
 type mockTransport struct {
 	URL string
@@ -212,12 +269,12 @@ func (t *mockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	*req2 = *req
 	req2.URL.Scheme = "http"
 	req2.URL.Host = req.Host
-	
+
 	// Remove api.github.com from the path and update it
 	path := req.URL.Path
 	path = path[len("/repos"):]
 	req2.URL.Path = path
-	
+
 	// Set the full URL to our test server
 	req2.URL.Host = t.URL[7:] // Remove "http://"
 	req2.Host = t.URL[7:]     // Remove "http://"
@@ -240,7 +297,8 @@ func mockGitHubAPI(t *testing.T) *httptest.Server {
 			{"name": ".github", "type": "dir", "html_url": "https://github.com/ethpandaops/dencun-devnets/tree/main/.github"},
 			{"name": ".gitignore", "type": "file", "html_url": "https://github.com/ethpandaops/dencun-devnets/blob/main/.gitignore"},
 			{"name": "README.md", "type": "file", "html_url": "https://github.com/ethpandaops/dencun-devnets/blob/main/README.md"},
-			{"name": "network-configs", "type": "dir", "html_url": "https://github.com/ethpandaops/dencun-devnets/tree/main/network-configs"}
+			{"name": "network-configs", "type": "dir", "html_url": "https://github.com/ethpandaops/dencun-devnets/tree/main/network-configs"},
+			{"name": "kubernetes", "type": "dir", "html_url": "https://github.com/ethpandaops/dencun-devnets/tree/main/kubernetes"}
 		]`))
 	})
 
@@ -261,7 +319,90 @@ func mockGitHubAPI(t *testing.T) *httptest.Server {
 		]`))
 	})
 
+	// Mock kubernetes directory paths for all the networks to mark them as active
+	networks := []string{"devnet-10", "devnet-11", "devnet-12", "devnet-4", "devnet-5", "gsf-1", "gsf-2", "msf-1", "sepolia-sf1"}
+	for _, network := range networks {
+		path := fmt.Sprintf("/ethpandaops/dencun-devnets/contents/kubernetes/%s", network)
+		mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[
+				{"name": "some-file.yaml", "type": "file", "html_url": "https://github.com/ethpandaops/dencun-devnets/blob/main/kubernetes/` + network + `/some-file.yaml"}
+			]`))
+		})
+	}
+
 	// Return test server
 	server := httptest.NewServer(mux)
+	return server
+}
+
+// Mock GitHub API with status checking.
+func mockGitHubAPIWithStatus(t *testing.T) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+
+	// Mock repository contents
+	mux.HandleFunc("/ethpandaops/pectra-devnets/contents", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[
+			{"name": ".github", "type": "dir", "html_url": "https://github.com/ethpandaops/pectra-devnets/tree/main/.github"},
+			{"name": "network-configs", "type": "dir", "html_url": "https://github.com/ethpandaops/pectra-devnets/tree/main/network-configs"},
+			{"name": "kubernetes", "type": "dir", "html_url": "https://github.com/ethpandaops/pectra-devnets/tree/main/kubernetes"},
+			{"name": "kubernetes-archive", "type": "dir", "html_url": "https://github.com/ethpandaops/pectra-devnets/tree/main/kubernetes-archive"}
+		]`))
+	})
+
+	// Mock network-configs contents
+	mux.HandleFunc("/ethpandaops/pectra-devnets/contents/network-configs", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[
+			{"name": "devnet-active", "type": "dir", "html_url": "https://github.com/ethpandaops/pectra-devnets/tree/main/network-configs/devnet-active"},
+			{"name": "devnet-inactive", "type": "dir", "html_url": "https://github.com/ethpandaops/pectra-devnets/tree/main/network-configs/devnet-inactive"},
+			{"name": "devnet-unknown", "type": "dir", "html_url": "https://github.com/ethpandaops/pectra-devnets/tree/main/network-configs/devnet-unknown"}
+		]`))
+	})
+
+	// Mock kubernetes directory - devnet-active exists here
+	mux.HandleFunc("/ethpandaops/pectra-devnets/contents/kubernetes/devnet-active", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[
+			{"name": "some-file.yaml", "type": "file", "html_url": "https://github.com/ethpandaops/pectra-devnets/blob/main/kubernetes/devnet-active/some-file.yaml"}
+		]`))
+	})
+
+	// Mock kubernetes directory - devnet-inactive does not exist here
+	mux.HandleFunc("/ethpandaops/pectra-devnets/contents/kubernetes/devnet-inactive", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message": "Not Found", "documentation_url": "https://docs.github.com"}`))
+	})
+
+	// Mock kubernetes directory - devnet-unknown does not exist here
+	mux.HandleFunc("/ethpandaops/pectra-devnets/contents/kubernetes/devnet-unknown", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message": "Not Found", "documentation_url": "https://docs.github.com"}`))
+	})
+
+	// Mock kubernetes-archive directory - devnet-inactive exists here
+	mux.HandleFunc("/ethpandaops/pectra-devnets/contents/kubernetes-archive/devnet-inactive", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[
+			{"name": "some-file.yaml", "type": "file", "html_url": "https://github.com/ethpandaops/pectra-devnets/blob/main/kubernetes-archive/devnet-inactive/some-file.yaml"}
+		]`))
+	})
+
+	// Mock kubernetes-archive directory - devnet-unknown does not exist here
+	mux.HandleFunc("/ethpandaops/pectra-devnets/contents/kubernetes-archive/devnet-unknown", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message": "Not Found", "documentation_url": "https://docs.github.com"}`))
+	})
+
+	// Return test server
+	server := httptest.NewServer(mux)
+
 	return server
 }


### PR DESCRIPTION
This commit introduces logic to determine the status of a discovered network based on whether a directory with the network's name exists within the `kubernetes/` or `kubernetes-archive/` directories in the GitHub repository.

- If a network directory exists in `kubernetes/`, the status is set to "active".
- If a network directory exists in `kubernetes-archive/`, the status is set to "inactive".
- Otherwise, the status remains "unknown".

This provides a more accurate representation of the network's current state within the repository's structure.

A new test `TestProvider_DiscoverNetworkStatus` has been added to verify this new functionality.