### PR TITLE
feat(cmd): adds genesis cfg

### DIFF
--- a/cmd/cartographoor/cmd/run.go
+++ b/cmd/cartographoor/cmd/run.go
@@ -12,7 +12,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	
+
 	"github.com/ethpandaops/cartographoor/pkg/utils"
 
 	"github.com/ethpandaops/cartographoor/pkg/discovery"
@@ -21,11 +21,13 @@ import (
 )
 
 type runConfig struct {
-	LoggingLevel string `mapstructure:"logging.level"`
-	ConfigFile   string
-	Discovery    discovery.Config `mapstructure:"discovery"`
-	Storage      s3.Config        `mapstructure:"storage"`
-	RunOnce      bool             `mapstructure:"runOnce"`
+	Logging struct {
+		Level string `mapstructure:"level"`
+	} `mapstructure:"logging"`
+	ConfigFile string
+	Discovery  discovery.Config `mapstructure:"discovery"`
+	Storage    s3.Config        `mapstructure:"storage"`
+	RunOnce    bool             `mapstructure:"runOnce"`
 }
 
 func newRunCmd(log *logrus.Logger) *cobra.Command {
@@ -40,7 +42,7 @@ func newRunCmd(log *logrus.Logger) *cobra.Command {
 
 			if cfg.ConfigFile != "" {
 				v.SetConfigFile(cfg.ConfigFile)
-				
+
 				// Read and process the config file with environment variable substitution
 				if err := readConfigWithEnvSubst(v); err != nil {
 					return err
@@ -55,7 +57,7 @@ func newRunCmd(log *logrus.Logger) *cobra.Command {
 			}
 
 			// Set log level
-			level, err := logrus.ParseLevel(cfg.LoggingLevel)
+			level, err := logrus.ParseLevel(cfg.Logging.Level)
 			if err == nil {
 				log.SetLevel(level)
 			}
@@ -66,7 +68,7 @@ func newRunCmd(log *logrus.Logger) *cobra.Command {
 
 	// Define flags
 	cmd.Flags().StringVar(&cfg.ConfigFile, "config", "", "Path to config file")
-	cmd.Flags().StringVar(&cfg.LoggingLevel, "logging.level", "info", "Logging level (trace, debug, info, warn, error, fatal, panic)")
+	cmd.Flags().StringVar(&cfg.Logging.Level, "logging.level", "info", "Logging level (trace, debug, info, warn, error, fatal, panic)")
 	cmd.Flags().BoolVar(&cfg.RunOnce, "once", false, "Run discovery once and exit")
 
 	return cmd

--- a/cmd/cartographoor/main.go
+++ b/cmd/cartographoor/main.go
@@ -10,6 +10,9 @@ import (
 func main() {
 	log := logrus.New()
 	log.SetOutput(os.Stdout)
+
+	// Log level will be properly set by the configuration in cmd.NewRootCommand
+	// Default to info level
 	log.SetLevel(logrus.InfoLevel)
 
 	if err := cmd.NewRootCommand(log).Execute(); err != nil {

--- a/pkg/discovery/types.go
+++ b/pkg/discovery/types.go
@@ -7,13 +7,27 @@ import (
 
 // Network represents an Ethereum network.
 type Network struct {
-	Name        string    `json:"name"`
-	Repository  string    `json:"repository"`
-	Path        string    `json:"path"`
-	URL         string    `json:"url,omitempty"`
-	Description string    `json:"description,omitempty"`
-	Status      string    `json:"status"`
-	LastUpdated time.Time `json:"lastUpdated"`
+	Name          string         `json:"name"`
+	Repository    string         `json:"repository"`
+	Path          string         `json:"path"`
+	URL           string         `json:"url,omitempty"`
+	Description   string         `json:"description,omitempty"`
+	Status        string         `json:"status"`
+	LastUpdated   time.Time      `json:"lastUpdated"`
+	GenesisConfig *GenesisConfig `json:"genesisConfig,omitempty"`
+}
+
+// GenesisConfig represents the configuration URLs for a network.
+type GenesisConfig struct {
+	ConsensusLayer []ConfigFile `json:"consensusLayer,omitempty"`
+	ExecutionLayer []ConfigFile `json:"executionLayer,omitempty"`
+	Metadata       []ConfigFile `json:"metadata,omitempty"`
+}
+
+// ConfigFile represents a configuration file URL.
+type ConfigFile struct {
+	Path string `json:"path"`
+	URL  string `json:"url"`
 }
 
 // Result represents the result of a discovery operation.
@@ -26,7 +40,7 @@ type Result struct {
 
 // GitHubRepositoryConfig represents the configuration for a GitHub repository source.
 type GitHubRepositoryConfig struct {
-	Name      string `mapstructure:"name"`
+	Name       string `mapstructure:"name"`
 	NamePrefix string `mapstructure:"namePrefix"`
 }
 

--- a/pkg/providers/github/network.go
+++ b/pkg/providers/github/network.go
@@ -1,0 +1,94 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/ethpandaops/cartographoor/pkg/discovery"
+	gh "github.com/google/go-github/v53/github"
+)
+
+// NetworkConfig contains configuration for a network.
+type NetworkConfig struct {
+	Name         string
+	PrefixedName string
+	Repository   string
+	Owner        string
+	Repo         string
+	Path         string
+	URL          string
+	Status       string
+	ConfigFiles  []string
+	Domain       string
+}
+
+// getNetworkConfigs gets the config files and domain for an active network.
+func (p *Provider) getNetworkConfigs(
+	ctx context.Context,
+	client *gh.Client,
+	owner, repo, kubePath, networkName string,
+) ([]string, string) {
+	valuesPath := path.Join(kubePath, "config", "values.yaml")
+	fileContent, _, _, err := client.Repositories.GetContents(ctx, owner, repo, valuesPath, nil)
+
+	if err == nil && fileContent != nil {
+		// Parse values.yaml to extract domain and config files
+		return p.parseValuesYaml(ctx, fileContent, networkName)
+	}
+
+	return nil, ""
+}
+
+// createNetwork creates a discovery.Network from a NetworkConfig.
+func (p *Provider) createNetwork(ctx context.Context, config *NetworkConfig) discovery.Network {
+	network := discovery.Network{
+		Name:        config.Name,
+		Repository:  config.Repository,
+		Path:        config.Path,
+		URL:         config.URL,
+		Status:      config.Status,
+		LastUpdated: time.Now(),
+	}
+
+	// If network is active and has configs, build the GenesisConfig
+	if config.Status == "active" && config.Domain != "" && len(config.ConfigFiles) > 0 {
+		network.GenesisConfig = p.buildGenesisConfig(config)
+	}
+
+	return network
+}
+
+// buildGenesisConfig builds a GenesisConfig from network config files.
+func (p *Provider) buildGenesisConfig(config *NetworkConfig) *discovery.GenesisConfig {
+	genesisConfig := &discovery.GenesisConfig{
+		ConsensusLayer: []discovery.ConfigFile{},
+		ExecutionLayer: []discovery.ConfigFile{},
+		Metadata:       []discovery.ConfigFile{},
+	}
+
+	for _, configPath := range config.ConfigFiles {
+		url := fmt.Sprintf("https://config.%s%s", config.Domain, configPath)
+
+		configFile := discovery.ConfigFile{
+			Path: configPath,
+			URL:  url,
+		}
+
+		// Categorize files based on path and filename
+		if strings.HasPrefix(configPath, "/metadata/") {
+			// Add only to metadata section
+			genesisConfig.Metadata = append(genesisConfig.Metadata, configFile)
+		} else if strings.HasPrefix(configPath, "/cl/") {
+			// Consensus layer specific paths
+			genesisConfig.ConsensusLayer = append(genesisConfig.ConsensusLayer, configFile)
+		} else if strings.HasPrefix(configPath, "/el/") {
+			// Execution layer specific paths
+			genesisConfig.ExecutionLayer = append(genesisConfig.ExecutionLayer, configFile)
+		}
+	}
+
+	return genesisConfig
+}

--- a/pkg/providers/github/parser.go
+++ b/pkg/providers/github/parser.go
@@ -1,0 +1,101 @@
+package github
+
+import (
+	"context"
+	"strings"
+
+	gh "github.com/google/go-github/v53/github"
+)
+
+const (
+	networkConfigDir     = "network-configs"
+	kubernetesDir        = "kubernetes"
+	kubernetesArchiveDir = "kubernetes-archive"
+	active               = "active"
+	inactive             = "inactive"
+	unknown              = "unknown"
+)
+
+// parseValuesYaml decodes the content of values.yaml and extracts config file paths and domain.
+func (p *Provider) parseValuesYaml(
+	ctx context.Context,
+	fileContent *gh.RepositoryContent,
+	networkName string,
+) ([]string, string) {
+	// Get content from GitHub response
+	content, err := fileContent.GetContent()
+	if err != nil {
+		p.log.WithError(err).WithField("network", networkName).Error("Failed to decode values.yaml content")
+
+		return nil, ""
+	}
+
+	// Extract domain
+	domain := p.extractDomain(content)
+
+	// Extract config file paths
+	configPaths := p.extractConfigPaths(content)
+
+	return configPaths, domain
+}
+
+// extractDomain extracts the domain from values.yaml content.
+func (p *Provider) extractDomain(content string) string {
+	var domain string
+
+	for _, line := range strings.Split(content, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "domain:") {
+			parts := strings.SplitN(line, ":", 2)
+			if len(parts) > 1 {
+				domain = strings.TrimSpace(parts[1])
+
+				break
+			}
+		}
+	}
+
+	return domain
+}
+
+// extractConfigPaths extracts the config file paths from values.yaml content.
+func (p *Provider) extractConfigPaths(content string) []string {
+	var (
+		configPaths     []string
+		inConfigSection = false
+		inFilesSection  = false
+	)
+
+	for _, line := range strings.Split(content, "\n") {
+		trimmedLine := strings.TrimSpace(line)
+
+		// Check if we're entering the config section
+		if strings.HasPrefix(trimmedLine, "config:") {
+			inConfigSection = true
+
+			continue
+		}
+
+		// Check if we're entering the files section inside config
+		if inConfigSection && strings.HasPrefix(trimmedLine, "files:") {
+			inFilesSection = true
+
+			continue
+		}
+
+		// Process file paths inside the files section
+		if inConfigSection && inFilesSection && strings.HasPrefix(trimmedLine, "- path:") {
+			parts := strings.SplitN(trimmedLine, ":", 2)
+			if len(parts) > 1 {
+				configPaths = append(configPaths, strings.TrimSpace(parts[1]))
+			}
+		}
+
+		// Only exit the config section if we're at a new top-level section (indicated by a line with no indentation)
+		if inConfigSection && !strings.HasPrefix(trimmedLine, "-") && !strings.HasPrefix(trimmedLine, "#") &&
+			trimmedLine != "" && !strings.HasPrefix(line, " ") && !strings.HasPrefix(line, "\t") {
+			break
+		}
+	}
+
+	return configPaths
+}

--- a/pkg/providers/github/status.go
+++ b/pkg/providers/github/status.go
@@ -1,0 +1,42 @@
+package github
+
+import (
+	"context"
+	"path"
+
+	gh "github.com/google/go-github/v53/github"
+)
+
+// determineNetworkStatus determines if a network is active, inactive, or unknown.
+func (p *Provider) determineNetworkStatus(
+	ctx context.Context,
+	client *gh.Client,
+	owner, repo, networkName string,
+) (string, []string, string) {
+	var (
+		status      = unknown
+		configFiles []string
+		domain      string
+	)
+
+	// Check if network exists in kubernetes directory (active).
+	kubePath := path.Join(kubernetesDir, networkName)
+
+	_, _, resp, err := client.Repositories.GetContents(ctx, owner, repo, kubePath, nil)
+	if err == nil || (resp != nil && resp.StatusCode != 404) {
+		status = active
+
+		// For active networks, try to get config values
+		configFiles, domain = p.getNetworkConfigs(ctx, client, owner, repo, kubePath, networkName)
+	} else {
+		// Check if network exists in kubernetes-archive directory (inactive).
+		archivePath := path.Join(kubernetesArchiveDir, networkName)
+
+		_, _, resp, err := client.Repositories.GetContents(ctx, owner, repo, archivePath, nil)
+		if err == nil || (resp != nil && resp.StatusCode != 404) {
+			status = inactive
+		}
+	}
+
+	return status, configFiles, domain
+}


### PR DESCRIPTION
- Adds genesis cfg to output - see example json below.
- Splits out/extracts discovery functionality to be more manageable - as there is more coming.
- Ensure logging level is grok'd from confg


```json
{
  "networks": {
    "pectra-devnet-6": {
      "name": "devnet-6",
      "repository": "ethpandaops/pectra-devnets",
      "path": "network-configs/devnet-6",
      "url": "https://github.com/ethpandaops/pectra-devnets/tree/master/network-configs/devnet-6",
      "status": "active",
      "lastUpdated": "2025-05-06T09:49:53.915675+10:00",
      "genesis_config": {
        "consensus_layer": [
          {
            "path": "/cl/bootstrap_nodes.txt",
            "url": "https://config.pectra-devnet-6.ethpandaops.io/cl/bootstrap_nodes.txt"
          },
          ...
        ],
        "execution_layer": [
          {
            "path": "/el/enodes.txt",
            "url": "https://config.pectra-devnet-6.ethpandaops.io/el/enodes.txt"
          },
          ...
        ],
        "metadata": [
          {
            "path": "/metadata/besu.json",
            "url": "https://config.pectra-devnet-6.ethpandaops.io/metadata/besu.json"
          },
          ...
        ]
      }
    }
  },
  "lastUpdate": "2025-05-06T09:49:59.602997+10:00",
  "duration": 18.690225958,
  "providers": [
    {}
  ]
}
```