### PR TITLE
feat: introduce svc urls to payload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+coverage.out
+coverage.html
 
 # Dependency directories (remove the comment below if you want to check in your lock files)
 vendor/

--- a/pkg/discovery/types.go
+++ b/pkg/discovery/types.go
@@ -15,6 +15,23 @@ type Network struct {
 	Status        string         `json:"status"`
 	LastUpdated   time.Time      `json:"lastUpdated"`
 	GenesisConfig *GenesisConfig `json:"genesisConfig,omitempty"`
+	ServiceURLs   *ServiceURLs   `json:"serviceUrls,omitempty"`
+}
+
+// ServiceURLs contains URLs for various network services.
+type ServiceURLs struct {
+	Faucet         string `json:"faucet,omitempty"`
+	JSONRPC        string `json:"jsonRpc,omitempty"`
+	BeaconRPC      string `json:"beaconRpc,omitempty"`
+	Explorer       string `json:"explorer,omitempty"`
+	BeaconExplorer string `json:"beaconExplorer,omitempty"`
+	Forkmon        string `json:"forkmon,omitempty"`
+	Assertoor      string `json:"assertoor,omitempty"`
+	Dora           string `json:"dora,omitempty"`
+	CheckpointSync string `json:"checkpointSync,omitempty"`
+	Blobscan       string `json:"blobscan,omitempty"`
+	Ethstats       string `json:"ethstats,omitempty"`
+	DevnetSpec     string `json:"devnetSpec,omitempty"`
 }
 
 // GenesisConfig represents the configuration URLs for a network.

--- a/pkg/providers/github/network.go
+++ b/pkg/providers/github/network.go
@@ -53,9 +53,17 @@ func (p *Provider) createNetwork(ctx context.Context, config *NetworkConfig) dis
 		LastUpdated: time.Now(),
 	}
 
-	// If network is active and has configs, build the GenesisConfig
-	if config.Status == "active" && config.Domain != "" && len(config.ConfigFiles) > 0 {
-		network.GenesisConfig = p.buildGenesisConfig(config)
+	// If network is active, add service URLs and GenesisConfig
+	if config.Status == "active" {
+		if config.Domain != "" {
+			// Add service URLs
+			network.ServiceURLs = p.getServiceURLs(ctx, config.Domain)
+
+			// Add GenesisConfig if we have config files
+			if len(config.ConfigFiles) > 0 {
+				network.GenesisConfig = p.buildGenesisConfig(config)
+			}
+		}
 	}
 
 	return network

--- a/pkg/providers/github/services.go
+++ b/pkg/providers/github/services.go
@@ -1,0 +1,201 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/ethpandaops/cartographoor/pkg/discovery"
+)
+
+// Common service patterns for Ethereum networks.
+var servicePatterns = map[string]string{
+	"faucet":          "https://faucet.%s",
+	"json_rpc":        "https://rpc.%s",
+	"beacon_rpc":      "https://beacon.%s",
+	"explorer":        "https://explorer.%s",
+	"forkmon":         "https://forkmon.%s",
+	"assertoor":       "https://assertoor.%s",
+	"dora":            "https://dora.%s",
+	"checkpoint_sync": "https://checkpoint-sync.%s",
+	"ethstats":        "https://ethstats.%s",
+}
+
+// Special case services with custom patterns.
+var specialServicePatterns = map[string]func(string) string{
+	"beacon_explorer": func(domain string) string {
+		parts := strings.Split(domain, ".")
+		if len(parts) > 0 {
+			return fmt.Sprintf("https://%s.beaconcha.in", parts[0])
+		}
+
+		return ""
+	},
+	"blobscan": func(domain string) string {
+		// Global blobscan service.
+		return "https://blobscan.com"
+	},
+	"devnet_spec": func(domain string) string {
+		parts := strings.Split(domain, ".")
+		if len(parts) == 0 {
+			return ""
+		}
+
+		domainPrefix := parts[0]
+
+		// Extract prefix (e.g., "pectra", "dencun") and network name.
+		prefixParts := strings.SplitN(domainPrefix, "-", 2)
+		if len(prefixParts) != 2 {
+			return ""
+		}
+
+		prefix := prefixParts[0]      // e.g., "pectra", "dencun".
+		networkName := prefixParts[1] // e.g., "msf-1", "devnet-6".
+
+		// Construct the URL using the extracted prefix and network name.
+		return fmt.Sprintf("https://github.com/ethpandaops/%s-devnets/tree/master/network-configs/%s/metadata",
+			prefix, networkName)
+	},
+}
+
+// getServiceURLs constructs and validates service URLs for a network.
+func (p *Provider) getServiceURLs(ctx context.Context, domain string) *discovery.ServiceURLs {
+	services := &discovery.ServiceURLs{}
+	client := &http.Client{
+		Timeout: 2 * time.Second, // Short timeout for quick checks.
+	}
+
+	p.log.WithField("domain", domain).Debug("Checking service URLs")
+
+	// Use channels to collect results from goroutines.
+	type urlCheckResult struct {
+		serviceKey string
+		url        string
+		valid      bool
+	}
+
+	var (
+		resultCh  = make(chan urlCheckResult)
+		numChecks int
+	)
+
+	// Start goroutines for common services
+	for serviceKey, pattern := range servicePatterns {
+		numChecks++
+
+		go func(key, pattern string) {
+			url := fmt.Sprintf(pattern, domain)
+			valid := p.isURLValid(ctx, client, url)
+
+			resultCh <- urlCheckResult{
+				serviceKey: key,
+				url:        url,
+				valid:      valid,
+			}
+		}(serviceKey, pattern)
+	}
+
+	// Start goroutines for special services that need validation
+	for serviceKey, patternFunc := range specialServicePatterns {
+		// Skip static URLs that don't need validation.
+		//nolint:goconst // No need.
+		if serviceKey == "devnet_spec" || serviceKey == "blobscan" {
+			continue
+		}
+
+		url := patternFunc(domain)
+		if url != "" {
+			numChecks++
+
+			go func(key, url string) {
+				valid := p.isURLValid(ctx, client, url)
+
+				resultCh <- urlCheckResult{
+					serviceKey: key,
+					url:        url,
+					valid:      valid,
+				}
+			}(serviceKey, url)
+		}
+	}
+
+	// Collect results
+	for i := 0; i < numChecks; i++ {
+		result := <-resultCh
+
+		p.log.WithFields(map[string]interface{}{
+			"service": result.serviceKey,
+			"url":     result.url,
+			"valid":   result.valid,
+		}).Debug("Checked service URL")
+
+		if result.valid {
+			switch result.serviceKey {
+			case "faucet":
+				services.Faucet = result.url
+			case "json_rpc":
+				services.JSONRPC = result.url
+			case "beacon_rpc":
+				services.BeaconRPC = result.url
+			case "explorer":
+				services.Explorer = result.url
+			case "forkmon":
+				services.Forkmon = result.url
+			case "assertoor":
+				services.Assertoor = result.url
+			case "dora":
+				services.Dora = result.url
+			case "checkpoint_sync":
+				services.CheckpointSync = result.url
+			case "ethstats":
+				services.Ethstats = result.url
+			case "beacon_explorer":
+				services.BeaconExplorer = result.url
+			}
+		}
+	}
+
+	// Add static services that don't need validation
+	for serviceKey, patternFunc := range specialServicePatterns {
+		if serviceKey == "devnet_spec" || serviceKey == "blobscan" {
+			url := patternFunc(domain)
+			if url != "" {
+				switch serviceKey {
+				case "devnet_spec":
+					services.DevnetSpec = url
+				case "blobscan":
+					// Always use the global blobscan.com
+					services.Blobscan = url
+				}
+
+				p.log.WithFields(map[string]interface{}{
+					"service": serviceKey,
+					"url":     url,
+					"valid":   true, // Assumed valid for static URLs
+				}).Debug("Added static service URL without validation")
+			}
+		}
+	}
+
+	return services
+}
+
+// isURLValid checks if a URL is reachable.
+func (p *Provider) isURLValid(ctx context.Context, client *http.Client, url string) bool {
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, url, nil)
+	if err != nil {
+		return false
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+
+	// Consider 2xx, 3xx, and some 4xx status codes as valid
+	// 404 might be valid for an API that exists but the endpoint is not found
+	return resp.StatusCode < 500
+}

--- a/pkg/providers/github/services_test.go
+++ b/pkg/providers/github/services_test.go
@@ -1,0 +1,97 @@
+package github
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetServiceURLs tests the service URL discovery functionality.
+func TestGetServiceURLs(t *testing.T) {
+	log := logrus.New()
+	log.SetLevel(logrus.DebugLevel)
+
+	provider, err := NewProvider(log)
+	require.NoError(t, err)
+
+	// Create a test server that simulates valid/invalid service endpoints
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Successful endpoints
+		validEndpoints := map[string]bool{
+			"/faucet.test-domain.com":          true,
+			"/rpc.test-domain.com":             true,
+			"/beacon.test-domain.com":          true,
+			"/test-domain.beaconcha.in":        true,
+			"/checkpoint-sync.test-domain.com": true,
+		}
+
+		if validEndpoints[r.URL.Path] {
+			w.WriteHeader(http.StatusOK)
+
+			return
+		}
+
+		// Server error responses for invalid services
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	// Create a test context
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Test directly the isURLValid function with our test server
+	client := &http.Client{Timeout: 2 * time.Second}
+
+	// Test valid URL
+	validReq, err := http.NewRequest("HEAD", server.URL+"/rpc.test-domain.com", nil)
+	require.NoError(t, err)
+	validResp, err := client.Do(validReq)
+	require.NoError(t, err)
+	defer validResp.Body.Close()
+	assert.Less(t, validResp.StatusCode, 500)
+	assert.True(t, provider.isURLValid(ctx, client, server.URL+"/rpc.test-domain.com"))
+
+	// Test invalid URL
+	invalidReq, err := http.NewRequest("HEAD", server.URL+"/explorer.test-domain.com", nil)
+	require.NoError(t, err)
+	invalidResp, err := client.Do(invalidReq)
+	require.NoError(t, err)
+	defer invalidResp.Body.Close()
+	assert.GreaterOrEqual(t, invalidResp.StatusCode, 500)
+	assert.False(t, provider.isURLValid(ctx, client, server.URL+"/explorer.test-domain.com"))
+
+	// Verify the service patterns
+	assert.Equal(t, "https://faucet.%s", servicePatterns["faucet"])
+	assert.Equal(t, "https://rpc.%s", servicePatterns["json_rpc"])
+	assert.Equal(t, "https://beacon.%s", servicePatterns["beacon_rpc"])
+
+	// Test the beaconcha.in special pattern
+	beaconchainURL := specialServicePatterns["beacon_explorer"]("test-domain.com")
+	assert.Equal(t, "https://test-domain.beaconcha.in", beaconchainURL)
+
+	// Test the blobscan special pattern
+	blobscanURL := specialServicePatterns["blobscan"]("test-domain.com")
+	assert.Equal(t, "https://blobscan.com", blobscanURL)
+
+	// Test the devnet spec special pattern
+	devnetDomain := "pectra-devnet-1.test-domain.com"
+	devnetSpecURL := specialServicePatterns["devnet_spec"](devnetDomain)
+	assert.Equal(t, "https://github.com/ethpandaops/pectra-devnets/tree/master/network-configs/devnet-1/metadata", devnetSpecURL)
+
+	// Test the invalid domain for devnet spec
+	emptySpecURL := specialServicePatterns["devnet_spec"]("")
+	assert.Equal(t, "", emptySpecURL)
+
+	// Test the non-prefixed domain for devnet spec
+	nonPrefixDomain := "invalid-domain"
+	nonPrefixedSpecURL := specialServicePatterns["devnet_spec"](nonPrefixDomain)
+	expectedURL := "https://github.com/ethpandaops/invalid-devnets/tree/master/network-configs/domain/metadata"
+	assert.Equal(t, expectedURL, nonPrefixedSpecURL)
+}


### PR DESCRIPTION
Pings each service url concurrently, to ensure it's valid before adding to config.

Example:

```json
{
  "networks": {
    "pectra-devnet-6": {
      "name": "devnet-6",
      "repository": "ethpandaops/pectra-devnets",
      "path": "network-configs/devnet-6",
      "url": "https://github.com/ethpandaops/pectra-devnets/tree/master/network-configs/devnet-6",
      "status": "active",
      "lastUpdated": "2025-05-06T11:10:50.938716+10:00",
      "genesisConfig": {},
      "serviceUrls": {
        "jsonRpc": "https://rpc.pectra-devnet-6.ethpandaops.io",
        "beaconRpc": "https://beacon.pectra-devnet-6.ethpandaops.io",
        "explorer": "https://explorer.pectra-devnet-6.ethpandaops.io",
        "beaconExplorer": "https://pectra-devnet-6.beaconcha.in",
        "forkmon": "https://forkmon.pectra-devnet-6.ethpandaops.io",
        "assertoor": "https://assertoor.pectra-devnet-6.ethpandaops.io",
        "dora": "https://dora.pectra-devnet-6.ethpandaops.io",
        "checkpointSync": "https://checkpoint-sync.pectra-devnet-6.ethpandaops.io",
        "blobscan": "https://blobscan.com",
        "ethstats": "https://ethstats.pectra-devnet-6.ethpandaops.io",
        "devnetSpec": "https://github.com/ethpandaops/pectra-devnets/tree/master/network-configs/devnet-6/metadata"
      }
    }
  }
}
```