### PR TITLE
feat(discovery): add client discovery functionality

### DIFF
--- a/pkg/discovery/clients.go
+++ b/pkg/discovery/clients.go
@@ -1,0 +1,216 @@
+package discovery
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	gh "github.com/google/go-github/v53/github"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/oauth2"
+)
+
+// Define a list of known clients.
+const (
+	CLLighthouse = "lighthouse"
+	CLPrysm      = "prysm"
+	CLLodestar   = "lodestar"
+	CLNimbus     = "nimbus"
+	CLTeku       = "teku"
+	CLGrandine   = "grandine"
+	ELNethermind = "nethermind"
+	ELNimbusel   = "nimbusel"
+	ELBesu       = "besu"
+	ELGeth       = "geth"
+	ELReth       = "reth"
+	ELErigon     = "erigon"
+	ELEthereumJS = "ethereumjs"
+)
+
+var (
+	// Buckets of known clients.
+	CLClients = []string{CLLighthouse, CLPrysm, CLLodestar, CLNimbus, CLTeku, CLGrandine}
+	ELClients = []string{ELNethermind, ELNimbusel, ELBesu, ELGeth, ELReth, ELErigon, ELEthereumJS}
+
+	// DefaultRepositories maps clients to their default source repositories.
+	DefaultRepositories = map[string]string{
+		CLLighthouse: "sigp/lighthouse",
+		CLPrysm:      "OffchainLabs/prysm",
+		CLLodestar:   "chainsafe/lodestar",
+		CLNimbus:     "status-im/nimbus-eth2",
+		CLTeku:       "ConsenSys/teku",
+		CLGrandine:   "grandinetech/grandine",
+		ELNethermind: "NethermindEth/nethermind",
+		ELNimbusel:   "status-im/nimbus-eth1",
+		ELBesu:       "hyperledger/besu",
+		ELGeth:       "ethereum/go-ethereum",
+		ELReth:       "paradigmxyz/reth",
+		ELErigon:     "erigontech/erigon",
+		ELEthereumJS: "ethereumjs/ethereumjs-monorepo",
+	}
+
+	// DefaultBranches maps clients to their default branches.
+	DefaultBranches = map[string]string{
+		CLLighthouse: "stable",
+		CLPrysm:      "develop",
+		CLLodestar:   "unstable",
+		CLNimbus:     "stable",
+		CLTeku:       "master",
+		CLGrandine:   "develop",
+		ELNethermind: "master",
+		ELNimbusel:   "master",
+		ELBesu:       "main",
+		ELGeth:       "master",
+		ELReth:       "main",
+		ELErigon:     "main",
+		ELEthereumJS: "master",
+	}
+
+	DefaultWebsiteURLs = map[string]string{
+		CLLighthouse: "https://lighthouse.sigmaprime.io/",
+		CLTeku:       "https://consensys.io/teku",
+		CLPrysm:      "https://www.offchainlabs.com/prysm",
+		CLLodestar:   "https://lodestar.chainsafe.io/",
+		CLNimbus:     "https://nimbus.team/",
+		CLGrandine:   "https://grandine.io/",
+		ELNethermind: "https://nethermind.io/",
+		ELNimbusel:   "https://nimbus.team/",
+		ELBesu:       "https://hyperledger.org/",
+		ELGeth:       "https://geth.ethereum.org/",
+		ELReth:       "https://www.paradigm.xyz/",
+		ELErigon:     "https://erigon.tech/",
+		ELEthereumJS: "https://ethereumjs.github.io/",
+	}
+
+	DefaultDocsURLs = map[string]string{
+		CLLighthouse: "https://lighthouse-book.sigmaprime.io/",
+		CLTeku:       "https://docs.teku.consensys.io/",
+		CLPrysm:      "https://www.offchainlabs.com/prysm/docs",
+		CLLodestar:   "https://chainsafe.github.io/lodestar/",
+		CLNimbus:     "https://nimbus.guide/index.html",
+		CLGrandine:   "https://docs.grandine.io/",
+		ELNethermind: "https://docs.nethermind.io/",
+		ELNimbusel:   "https://nimbus.guide/index.html",
+		ELBesu:       "https://besu.hyperledger.org/",
+		ELGeth:       "https://geth.ethereum.org/docs",
+		ELReth:       "https://reth.rs/",
+		ELErigon:     "https://docs.erigon.tech/",
+		ELEthereumJS: "https://ethereumjs.readthedocs.io/",
+	}
+)
+
+// Ensure ClientDiscoverer implements ClientDiscovererInterface.
+var _ ClientDiscovererInterface = (*ClientDiscoverer)(nil)
+
+// ClientDiscoverer handles fetching information about Ethereum clients.
+type ClientDiscoverer struct {
+	log    *logrus.Logger
+	client *gh.Client
+}
+
+// NewClientDiscoverer creates a new ClientDiscoverer.
+func NewClientDiscoverer(log *logrus.Logger, token string) *ClientDiscoverer {
+	log = log.WithField("module", "client_discoverer").Logger
+
+	var client *gh.Client
+
+	if token != "" {
+		ts := oauth2.StaticTokenSource(
+			&oauth2.Token{AccessToken: token},
+		)
+		tc := oauth2.NewClient(context.Background(), ts)
+		client = gh.NewClient(tc)
+	} else {
+		client = gh.NewClient(nil)
+	}
+
+	return &ClientDiscoverer{
+		log:    log,
+		client: client,
+	}
+}
+
+// DiscoverClients fetches information about all known Ethereum clients.
+func (d *ClientDiscoverer) DiscoverClients(ctx context.Context) (map[string]ClientInfo, error) {
+	d.log.Info("Discovering client information")
+
+	clients := make(map[string]ClientInfo)
+
+	// Process all clients
+	allClients := append(CLClients, ELClients...)
+
+	for _, clientName := range allClients {
+		repo, ok := DefaultRepositories[clientName]
+		if !ok {
+			continue
+		}
+
+		branch, ok := DefaultBranches[clientName]
+		if !ok {
+			branch = ""
+		}
+
+		websiteURL, ok := DefaultWebsiteURLs[clientName]
+		if !ok {
+			websiteURL = ""
+		}
+
+		docsURL, ok := DefaultDocsURLs[clientName]
+		if !ok {
+			docsURL = ""
+		}
+
+		// Create client info
+		clientInfo := ClientInfo{
+			Name:       clientName,
+			Repository: repo,
+			Branch:     branch,
+			Logo:       fmt.Sprintf("https://ethpandaops.io/img/clients/%s.jpg", clientName),
+			WebsiteURL: websiteURL,
+			DocsURL:    docsURL,
+		}
+
+		// Try to fetch the latest version
+		version, err := d.getLatestVersion(ctx, repo)
+		if err != nil {
+			d.log.WithError(err).WithField("client", clientName).Warn("Failed to get latest version")
+		} else {
+			clientInfo.LatestVersion = version
+		}
+
+		clients[clientName] = clientInfo
+	}
+
+	d.log.WithField("count", len(clients)).Info("Client discovery complete")
+
+	return clients, nil
+}
+
+// getLatestVersion fetches the latest released version of a client.
+func (d *ClientDiscoverer) getLatestVersion(ctx context.Context, repo string) (string, error) {
+	parts := strings.Split(repo, "/")
+	if len(parts) != 2 {
+		return "", fmt.Errorf("invalid repository format: %s", repo)
+	}
+
+	owner, repoName := parts[0], parts[1]
+
+	// First try to get the latest release
+	release, _, err := d.client.Repositories.GetLatestRelease(ctx, owner, repoName)
+	if err == nil && release != nil && release.TagName != nil {
+		return *release.TagName, nil
+	}
+
+	// If no release found, try to get tags
+	opts := &gh.ListOptions{
+		PerPage: 1, // We only need the latest tag
+	}
+
+	tags, _, err := d.client.Repositories.ListTags(ctx, owner, repoName, opts)
+	if err == nil && len(tags) > 0 && tags[0].Name != nil {
+		return *tags[0].Name, nil
+	}
+
+	// If all else fails, return an empty string
+	return "", fmt.Errorf("no version information found")
+}

--- a/pkg/discovery/types.go
+++ b/pkg/discovery/types.go
@@ -78,10 +78,22 @@ type Stats struct {
 	NetworkNames     []string `json:"networkNames,omitempty"`
 }
 
+// ClientInfo represents details about an Ethereum client.
+type ClientInfo struct {
+	Name          string `json:"name"`
+	Repository    string `json:"repository"`
+	Branch        string `json:"branch"`
+	Logo          string `json:"logo"`
+	LatestVersion string `json:"latestVersion,omitempty"`
+	WebsiteURL    string `json:"websiteUrl,omitempty"`
+	DocsURL       string `json:"docsUrl,omitempty"`
+}
+
 // Result represents the result of a discovery operation.
 type Result struct {
 	NetworkMetadata map[string]RepositoryMetadata `json:"networkMetadata"`
 	Networks        map[string]Network            `json:"networks"`
+	Clients         map[string]ClientInfo         `json:"clients"`
 	LastUpdate      time.Time                     `json:"lastUpdate"`
 	Duration        float64                       `json:"duration"`
 	Providers       []Provider                    `json:"providers"`


### PR DESCRIPTION
This commit introduces the ability to discover information about various Ethereum clients.

- Adds a new `ClientDiscoverer` type and associated functions to fetch client details like repositories, branches, logos, latest versions, and documentation URLs.
- Defines a list of known consensus and execution layer clients and their default repositories, branches, and URLs.
- Integrates the `ClientDiscoverer` into the `Service` to include client information in the discovery results.
- Updates the `Result` type to include a map of `ClientInfo`.
- Adds a mock client discoverer for testing purposes.

Example:

```json
{
    "networkMetadata": {},
    "networks": {},
    "clients": {
      "besu": {
        "name": "besu",
        "repository": "hyperledger/besu",
        "branch": "main",
        "logo": "https://ethpandaops.io/img/clients/besu.jpg",
        "latestVersion": "25.4.1",
        "websiteUrl": "https://hyperledger.org/",
        "docsUrl": "https://besu.hyperledger.org/"
      },
      "erigon": {
        "name": "erigon",
        "repository": "erigontech/erigon",
        "branch": "main",
        "logo": "https://ethpandaops.io/img/clients/erigon.jpg",
        "latestVersion": "v3.0.3",
        "websiteUrl": "https://erigon.tech/",
        "docsUrl": "https://docs.erigon.tech/"
      },
      "geth": {
        "name": "geth",
        "repository": "ethereum/go-ethereum",
        "branch": "master",
        "logo": "https://ethpandaops.io/img/clients/geth.jpg",
        "latestVersion": "v1.15.11",
        "websiteUrl": "https://geth.ethereum.org/",
        "docsUrl": "https://geth.ethereum.org/docs"
      },
      ...
    }
}
```