### PR TITLE
feat(networks): append hiveURL if we have one

### DIFF
--- a/cmd/cartographoor/cmd/run.go
+++ b/cmd/cartographoor/cmd/run.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"os"
 	"os/signal"
 	"strings"
@@ -80,6 +81,10 @@ func runService(ctx context.Context, log *logrus.Logger, cfg *runConfig) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
+	httpClient := &http.Client{
+		Timeout: 10 * time.Second,
+	}
+
 	// Create discovery service
 	discoveryService, err := discovery.NewService(log, cfg.Discovery)
 	if err != nil {
@@ -93,7 +98,7 @@ func runService(ctx context.Context, log *logrus.Logger, cfg *runConfig) error {
 	}
 
 	// Register GitHub provider
-	githubProvider, err := github.NewProvider(log)
+	githubProvider, err := github.NewProvider(log, httpClient)
 	if err != nil {
 		return err
 	}

--- a/pkg/discovery/types.go
+++ b/pkg/discovery/types.go
@@ -19,6 +19,7 @@ type Network struct {
 	GenesisConfig *GenesisConfig `json:"genesisConfig,omitempty"`
 	ServiceURLs   *ServiceURLs   `json:"serviceUrls,omitempty"`
 	Images        *Images        `json:"images,omitempty"`
+	HiveURL       string         `json:"hiveUrl,omitempty"`
 }
 
 // Link represents a related link with title and URL.

--- a/pkg/providers/github/genesis.go
+++ b/pkg/providers/github/genesis.go
@@ -17,7 +17,7 @@ func (p *Provider) parseGenesisJSON(
 	genesisPath := path.Join(networkConfigDir, networkName, "metadata", "genesis.json")
 
 	// Try to get file content
-	fileContent, _, _, err := p.client.Repositories.GetContents(ctx, owner, repo, genesisPath, nil)
+	fileContent, _, _, err := p.githubClient.Repositories.GetContents(ctx, owner, repo, genesisPath, nil)
 	if err != nil {
 		return 0, 0, fmt.Errorf("failed to get genesis.json: %w", err)
 	}

--- a/pkg/providers/github/provider_test.go
+++ b/pkg/providers/github/provider_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestProvider_Name(t *testing.T) {
 	log := logrus.New()
-	provider, err := NewProvider(log)
+	provider, err := NewProvider(log, nil)
 	require.NoError(t, err)
 
 	assert.Equal(t, "github", provider.Name())
@@ -180,7 +180,7 @@ func TestProvider_Discover(t *testing.T) {
 			log := logrus.New()
 			log.SetLevel(logrus.DebugLevel)
 
-			provider, err := NewProvider(log)
+			provider, err := NewProvider(log, nil)
 			require.NoError(t, err)
 
 			// Set up mock API if needed
@@ -196,9 +196,9 @@ func TestProvider_Discover(t *testing.T) {
 					httpClient := &http.Client{
 						Transport: &mockTransport{URL: ts.URL},
 					}
-					provider.client = gh.NewClient(httpClient)
+					provider.githubClient = gh.NewClient(httpClient)
 				} else {
-					provider.client = gh.NewClient(nil)
+					provider.githubClient = gh.NewClient(nil)
 				}
 			}
 
@@ -262,7 +262,7 @@ func TestServiceURLs(t *testing.T) {
 	log := logrus.New()
 	log.SetLevel(logrus.DebugLevel)
 
-	provider, err := NewProvider(log)
+	provider, err := NewProvider(log, nil)
 	require.NoError(t, err)
 
 	// Create a test server that simulates valid/invalid service endpoints


### PR DESCRIPTION
Determines if given network has hive setup against it, if it does, returns qualified URL.

Example:

```json
{
  "networks": {
    "eof-devnet-0": {
      "name": "devnet-0",
      "repository": "ethpandaops/eof-devnets",
      "path": "network-configs/devnet-0",
      "url": "https://github.com/ethpandaops/eof-devnets/tree/master/network-configs/devnet-0",
      "status": "inactive",
      "lastUpdated": "2025-05-23T10:08:32.945762+10:00",
      "hiveUrl": "https://hive.ethpandaops.io/eof-devnet-0/index.html" <----
    },
    ...
  }
}
```