### PR TITLE
build: upgrade golangci-lint to v2.4.0 and migrate wsl to wsl_v5

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -40,7 +40,7 @@ linters:
     - unconvert
     - unused
     - whitespace
-    - wsl
+    - wsl_v5
   settings:
     errcheck:
       check-type-assertions: true
@@ -60,6 +60,10 @@ linters:
     nolintlint:
       require-explanation: true
       require-specific: true
+    wsl_v5:
+      allow-first-in-block: true
+      allow-whole-block: false
+      branch-max-lines: 2
   exclusions:
     generated: lax
     presets:
@@ -71,7 +75,7 @@ linters:
       - linters:
           - gocritic
           - gosec
-          - wsl
+          - wsl_v5
         path: _test\.go
     paths:
       - third_party$

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+golangci-lint 2.4.0

--- a/pkg/discovery/service.go
+++ b/pkg/discovery/service.go
@@ -79,9 +79,11 @@ func (s *Service) Start(ctx context.Context) error {
 				return
 			case result := <-s.resultChan:
 				s.mutex.Lock()
+
 				for _, fn := range s.resultFuncs {
 					fn(result)
 				}
+
 				s.mutex.Unlock()
 			}
 		}

--- a/pkg/inventory/service.go
+++ b/pkg/inventory/service.go
@@ -167,7 +167,9 @@ func (s *Service) generateInventories(ctx context.Context, networks map[string]d
 
 			// Store the inventory
 			mu.Lock()
+
 			inventories[name] = inventory
+
 			mu.Unlock()
 
 			successCount.Add(1)
@@ -206,9 +208,11 @@ func (s *Service) uploadInventories(ctx context.Context, inventories map[string]
 				s.log.WithError(err).WithField("network", name).Error("Failed to marshal inventory")
 
 				mu.Lock()
+
 				if uploadError == nil {
 					uploadError = fmt.Errorf("failed to marshal inventory for %s: %w", name, err)
 				}
+
 				mu.Unlock()
 
 				return
@@ -229,9 +233,11 @@ func (s *Service) uploadInventories(ctx context.Context, inventories map[string]
 				s.log.WithError(err).WithField("network", name).Error("Failed to upload inventory")
 
 				mu.Lock()
+
 				if uploadError == nil {
 					uploadError = fmt.Errorf("failed to upload inventory for %s: %w", name, err)
 				}
+
 				mu.Unlock()
 
 				return

--- a/pkg/providers/github/provider.go
+++ b/pkg/providers/github/provider.go
@@ -134,6 +134,7 @@ func (p *Provider) discoverRepositoryNetworks(
 
 		// Determine network status, configs, domain, and images
 		var images *discovery.Images
+
 		networkConfig.Status, networkConfig.ConfigFiles, networkConfig.Domain, images, networkConfig.HiveURL = p.getNetworkDetails(
 			ctx, githubClient, owner, repo, networkConfig.Name,
 		)


### PR DESCRIPTION
chore(.golangci.yml): rename wsl linter to wsl_v5 and add new settings
style: add blank lines after mutex locks to satisfy wsl_v5 rules