### PR TITLE
feat: add self-hosted DNS detection and dynamic URL generation

### DIFF
--- a/pkg/discovery/types.go
+++ b/pkg/discovery/types.go
@@ -20,6 +20,7 @@ type Network struct {
 	ServiceURLs   *ServiceURLs   `json:"serviceUrls,omitempty"`
 	Images        *Images        `json:"images,omitempty"`
 	HiveURL       string         `json:"hiveUrl,omitempty"`
+	SelfHostedDNS bool           `json:"selfHostedDns"`
 }
 
 // Link represents a related link with title and URL.

--- a/pkg/inventory/types.go
+++ b/pkg/inventory/types.go
@@ -29,6 +29,9 @@ type ClientInfo struct {
 	PeerCount     int               `json:"peerCount,omitempty"`
 	PeersInbound  int               `json:"peersInbound,omitempty"`
 	PeersOutbound int               `json:"peersOutbound,omitempty"`
+	SSH           string            `json:"ssh,omitempty"`
+	BeaconAPI     string            `json:"bn,omitempty"`  // For consensus clients
+	RPC           string            `json:"rpc,omitempty"` // For execution clients
 	Metadata      map[string]string `json:"metadata,omitempty"`
 }
 

--- a/pkg/providers/github/provider.go
+++ b/pkg/providers/github/provider.go
@@ -135,7 +135,7 @@ func (p *Provider) discoverRepositoryNetworks(
 		// Determine network status, configs, domain, and images
 		var images *discovery.Images
 
-		networkConfig.Status, networkConfig.ConfigFiles, networkConfig.Domain, images, networkConfig.HiveURL = p.getNetworkDetails(
+		networkConfig.Status, networkConfig.ConfigFiles, networkConfig.Domain, images, networkConfig.HiveURL, networkConfig.SelfHostedDNS = p.getNetworkDetails(
 			ctx, githubClient, owner, repo, networkConfig.Name,
 		)
 

--- a/pkg/providers/github/status.go
+++ b/pkg/providers/github/status.go
@@ -48,7 +48,7 @@ func (p *Provider) getNetworkDetails(
 	ctx context.Context,
 	client *gh.Client,
 	owner, repo, networkName string,
-) (status string, configFiles []string, domain string, images *discovery.Images, hiveURL string) {
+) (status string, configFiles []string, domain string, images *discovery.Images, hiveURL string, selfHostedDNS bool) {
 	// Get basic network status, configs, and domain
 	status, configFiles, domain = p.determineNetworkStatus(ctx, client, owner, repo, networkName)
 
@@ -67,5 +67,8 @@ func (p *Provider) getNetworkDetails(
 		}).Debug("hive is not available for network")
 	}
 
-	return status, configFiles, domain, images, hiveURL
+	// Check if network uses a self-hosted DNS server
+	selfHostedDNS = p.checkSelfHostedDNS(ctx, client, owner, repo, networkName)
+
+	return status, configFiles, domain, images, hiveURL, selfHostedDNS
 }


### PR DESCRIPTION
Add SelfHostedDNS field to Network type to track whether a network uses self-hosted DNS servers instead of Cloudflare. This allows the inventory generator to construct correct SSH and API URLs based on the DNS type.

Update processConsensusClient and processExecutionClient to accept the full Network struct instead of just images, enabling access to the new SelfHostedDNS flag and network name for URL construction.

Add SSH, BeaconAPI and RPC fields to ClientInfo to expose the generated URLs in the inventory output.

Implement checkSelfHostedDNS helper that checks for the presence of ansible/inventories/{network}/group_vars/dns_server.yaml to determine if a network uses self-hosted DNS.

Update all related functions to pass through the SelfHostedDNS flag from the GitHub provider to the final network configuration.