### PR TITLE
refactor(inventory): pass full network name to generator methods

### DIFF
--- a/pkg/inventory/service.go
+++ b/pkg/inventory/service.go
@@ -150,7 +150,7 @@ func (s *Service) generateInventories(ctx context.Context, networks map[string]d
 			defer sem.Release(1)
 
 			// Generate inventory for this network
-			inventory, err := s.generator.GenerateForNetwork(ctx, network)
+			inventory, err := s.generator.GenerateForNetwork(ctx, name, network)
 			if err != nil {
 				s.log.WithError(err).WithField("network", name).Error("Failed to generate inventory")
 				failureCount.Add(1)


### PR DESCRIPTION
Replace network.Name with explicit fullNetworkName parameter to ensure consistent naming across DNS records and inventory data.