### PR TITLE
feat: move static networks from hard-coded to config-driven

### DIFF
--- a/.github/config.production.yaml
+++ b/.github/config.production.yaml
@@ -12,6 +12,92 @@ discovery:
   # Discovery interval (default: 1h)
   interval: 1h
 
+  # Static network configuration
+  static:
+    networks:
+      - name: mainnet
+        description: Production Ethereum network
+        chainId: 1
+        genesisTime: 1606824023
+        serviceUrls:
+          ethstats: https://ethstats.mainnet.ethpandaops.io
+          forkmon: https://forkmon.mainnet.ethpandaops.io
+          blobArchive: https://blob-archive.mainnet.ethpandaops.io
+          forky: https://forky.mainnet.ethpandaops.io
+          tracoor: https://tracoor.mainnet.ethpandaops.io
+        forks:
+          consensus:
+            electra:
+              epoch: 364032
+              minClientVersions:
+                grandine: "1.1.0"
+                lighthouse: "7.0.0"
+                lodestar: "1.29.0"
+                nimbus: "25.4.1"
+                prysm: "6.0.0"
+                teku: "25.4.1"
+
+      - name: sepolia
+        description: Smaller testnet for application development with controlled validator set.
+        chainId: 11155111
+        genesisTime: 1655726400
+        serviceUrls:
+          dora: https://dora.sepolia.ethpandaops.io
+          beaconExplorer: https://dora.sepolia.ethpandaops.io
+          checkpointSync: https://checkpoint-sync.sepolia.ethpandaops.io
+          ethstats: https://ethstats.sepolia.ethpandaops.io
+          forkmon: https://forkmon.sepolia.ethpandaops.io
+          blobArchive: https://blob-archive.sepolia.ethpandaops.io
+          forky: https://forky.sepolia.ethpandaops.io
+          tracoor: https://tracoor.sepolia.ethpandaops.io
+        forks:
+          consensus:
+            electra:
+              epoch: 222464
+              minClientVersions:
+                grandine: "1.0.0"
+                lighthouse: "7.0.0-beta.0"
+                lodestar: "1.27.0"
+                nimbus: "25.2.0"
+                prysm: "5.3.0"
+                teku: "25.2.0"
+
+      - name: holesky
+        description: Long-term public testnet designed for staking/validator testing with high validator counts.
+        chainId: 17000
+        genesisTime: 1695902400
+        serviceUrls:
+          dora: https://dora.holesky.ethpandaops.io
+          beaconExplorer: https://dora.holesky.ethpandaops.io
+          checkpointSync: https://checkpoint-sync.holesky.ethpandaops.io
+          ethstats: https://ethstats.holesky.ethpandaops.io
+          forkmon: https://forkmon.holesky.ethpandaops.io
+          blobArchive: https://blob-archive.holesky.ethpandaops.io
+          forky: https://forky.holesky.ethpandaops.io
+          tracoor: https://tracoor.holesky.ethpandaops.io
+        forks:
+          consensus:
+            electra:
+              epoch: 0  # Or appropriate epoch when known
+              # minClientVersions can be omitted if not yet determined
+
+      - name: hoodi
+        description: New public testnet (launched March 2025) designed for validator testing and protocol upgrades, replacing Holesky.
+        chainId: 560048
+        genesisTime: 1742213400
+        serviceUrls:
+          dora: https://dora.hoodi.ethpandaops.io
+          beaconExplorer: https://dora.hoodi.ethpandaops.io
+          checkpointSync: https://checkpoint-sync.hoodi.ethpandaops.io
+          forkmon: https://forkmon.hoodi.ethpandaops.io
+          forky: https://forky.hoodi.ethpandaops.io
+          tracoor: https://tracoor.hoodi.ethpandaops.io
+        forks:
+          consensus:
+            electra:
+              epoch: 2048
+              # minClientVersions will be added when specifications are finalized
+
   # GitHub discovery configuration
   github:
     # List of repositories to check for networks

--- a/pkg/discovery/types.go
+++ b/pkg/discovery/types.go
@@ -21,6 +21,7 @@ type Network struct {
 	Images        *Images        `json:"images,omitempty"`
 	HiveURL       string         `json:"hiveUrl,omitempty"`
 	SelfHostedDNS bool           `json:"selfHostedDns"`
+	Forks         *ForksConfig   `json:"forks,omitempty"`
 }
 
 // Link represents a related link with title and URL.
@@ -119,10 +120,34 @@ type GitHubRepositoryConfig struct {
 	Links       []Link `mapstructure:"links"`
 }
 
+// StaticNetworkConfig represents the configuration for a static network.
+type StaticNetworkConfig struct {
+	Name        string            `mapstructure:"name"`
+	Description string            `mapstructure:"description"`
+	ChainID     uint64            `mapstructure:"chainId"`
+	GenesisTime uint64            `mapstructure:"genesisTime"`
+	ServiceURLs map[string]string `mapstructure:"serviceUrls"`
+	Forks       *ForksConfig      `mapstructure:"forks"`
+}
+
+// ForksConfig represents fork configuration for both consensus and execution layers.
+type ForksConfig struct {
+	Consensus map[string]ForkConfig `mapstructure:"consensus"`
+}
+
+// ForkConfig represents configuration for a specific fork.
+type ForkConfig struct {
+	Epoch             uint64            `mapstructure:"epoch"`
+	MinClientVersions map[string]string `mapstructure:"minClientVersions"`
+}
+
 // Config represents the configuration for the discovery service.
 type Config struct {
 	Interval time.Duration `mapstructure:"interval"`
-	GitHub   struct {
+	Static   struct {
+		Networks []StaticNetworkConfig `mapstructure:"networks"`
+	} `mapstructure:"static"`
+	GitHub struct {
 		Repositories []GitHubRepositoryConfig `mapstructure:"repositories"`
 		Token        string                   `mapstructure:"token"`
 	} `mapstructure:"github"`

--- a/pkg/providers/static/provider_test.go
+++ b/pkg/providers/static/provider_test.go
@@ -27,7 +27,6 @@ func (p *mockGitHubProvider) Discover(ctx context.Context, config discovery.Conf
 		Repository:  "ethpandaops/mock-devnets",
 		Path:        "network-configs/devnet-1",
 		Description: "Mock Devnet 1",
-		Status:      "active",
 		LastUpdated: time.Now(),
 		ServiceURLs: &discovery.ServiceURLs{
 			Faucet:    "https://faucet.devnet-1.ethpandaops.io",
@@ -43,8 +42,83 @@ func TestCombinedProviders(t *testing.T) {
 	log := logrus.New()
 	log.SetLevel(logrus.DebugLevel)
 
+	// Create config with static networks
+	config := discovery.Config{}
+	config.Static.Networks = []discovery.StaticNetworkConfig{
+		{
+			Name:        "mainnet",
+			Description: "Production Ethereum network",
+			ChainID:     1,
+			GenesisTime: 1606824023,
+			ServiceURLs: map[string]string{
+				"ethstats":    "https://ethstats.mainnet.ethpandaops.io",
+				"forkmon":     "https://forkmon.mainnet.ethpandaops.io",
+				"blobArchive": "https://blob-archive.mainnet.ethpandaops.io",
+				"forky":       "https://forky.mainnet.ethpandaops.io",
+				"tracoor":     "https://tracoor.mainnet.ethpandaops.io",
+			},
+			Forks: &discovery.ForksConfig{
+				Consensus: map[string]discovery.ForkConfig{
+					"electra": {
+						Epoch: 364032,
+						MinClientVersions: map[string]string{
+							"lighthouse": "7.0.0",
+							"prysm":      "6.0.0",
+						},
+					},
+				},
+			},
+		},
+		{
+			Name:        "sepolia",
+			Description: "Smaller testnet for application development with controlled validator set.",
+			ChainID:     11155111,
+			GenesisTime: 1655726400,
+			ServiceURLs: map[string]string{
+				"dora":           "https://dora.sepolia.ethpandaops.io",
+				"beaconExplorer": "https://dora.sepolia.ethpandaops.io",
+				"checkpointSync": "https://checkpoint-sync.sepolia.ethpandaops.io",
+				"ethstats":       "https://ethstats.sepolia.ethpandaops.io",
+				"forkmon":        "https://forkmon.sepolia.ethpandaops.io",
+				"blobArchive":    "https://blob-archive.sepolia.ethpandaops.io",
+				"forky":          "https://forky.sepolia.ethpandaops.io",
+				"tracoor":        "https://tracoor.sepolia.ethpandaops.io",
+			},
+		},
+		{
+			Name:        "holesky",
+			Description: "Long-term public testnet designed for staking/validator testing with high validator counts.",
+			ChainID:     17000,
+			GenesisTime: 1695902400,
+			ServiceURLs: map[string]string{
+				"dora":           "https://dora.holesky.ethpandaops.io",
+				"beaconExplorer": "https://dora.holesky.ethpandaops.io",
+				"checkpointSync": "https://checkpoint-sync.holesky.ethpandaops.io",
+				"ethstats":       "https://ethstats.holesky.ethpandaops.io",
+				"forkmon":        "https://forkmon.holesky.ethpandaops.io",
+				"blobArchive":    "https://blob-archive.holesky.ethpandaops.io",
+				"forky":          "https://forky.holesky.ethpandaops.io",
+				"tracoor":        "https://tracoor.holesky.ethpandaops.io",
+			},
+		},
+		{
+			Name:        "hoodi",
+			Description: "New public testnet (launched March 2025) designed for validator testing and protocol upgrades, replacing Holesky.",
+			ChainID:     560048,
+			GenesisTime: 1742213400,
+			ServiceURLs: map[string]string{
+				"dora":           "https://dora.hoodi.ethpandaops.io",
+				"beaconExplorer": "https://dora.hoodi.ethpandaops.io",
+				"checkpointSync": "https://checkpoint-sync.hoodi.ethpandaops.io",
+				"forkmon":        "https://forkmon.hoodi.ethpandaops.io",
+				"forky":          "https://forky.hoodi.ethpandaops.io",
+				"tracoor":        "https://tracoor.hoodi.ethpandaops.io",
+			},
+		},
+	}
+
 	// Create discovery service
-	service, err := discovery.NewService(log, discovery.Config{})
+	service, err := discovery.NewService(log, config)
 	require.NoError(t, err)
 
 	// Register both providers
@@ -60,12 +134,20 @@ func TestCombinedProviders(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify we have networks from both providers
-	assert.Len(t, result.Networks, 5, "Should have 5 networks (5 from static, 1 from GitHub mock)")
+	assert.Len(t, result.Networks, 5, "Should have 5 networks (4 from static, 1 from GitHub mock)")
 	assert.Contains(t, result.Networks, "mainnet")
 	assert.Contains(t, result.Networks, "sepolia")
 	assert.Contains(t, result.Networks, "hoodi")
 	assert.Contains(t, result.Networks, "holesky")
 	assert.Contains(t, result.Networks, "devnet-1")
+
+	// Verify fork configuration is properly passed through
+	mainnet := result.Networks["mainnet"]
+	require.NotNil(t, mainnet.Forks)
+	require.NotNil(t, mainnet.Forks.Consensus)
+	require.Contains(t, mainnet.Forks.Consensus, "electra")
+	assert.Equal(t, uint64(364032), mainnet.Forks.Consensus["electra"].Epoch)
+	assert.Equal(t, "7.0.0", mainnet.Forks.Consensus["electra"].MinClientVersions["lighthouse"])
 
 	// Verify the providers in the result
 	providerNames := make([]string, 0, len(result.Providers))
@@ -85,16 +167,216 @@ func TestProvider_Name(t *testing.T) {
 	assert.Equal(t, "static", provider.Name())
 }
 
+func TestProvider_DiscoverWithForks(t *testing.T) {
+	log := logrus.New()
+	provider, err := NewProvider(log)
+	require.NoError(t, err)
+
+	t.Run("network with full fork configuration", func(t *testing.T) {
+		config := discovery.Config{}
+		config.Static.Networks = []discovery.StaticNetworkConfig{
+			{
+				Name:        "test-mainnet",
+				Description: "Test network with fork config",
+				ChainID:     1,
+				GenesisTime: 1606824023,
+				ServiceURLs: map[string]string{
+					"ethstats": "https://ethstats.test.io",
+				},
+				Forks: &discovery.ForksConfig{
+					Consensus: map[string]discovery.ForkConfig{
+						"electra": {
+							Epoch: 364032,
+							MinClientVersions: map[string]string{
+								"lighthouse": "7.0.0",
+								"prysm":      "6.0.0",
+								"teku":       "25.4.1",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		networks, err := provider.Discover(context.Background(), config)
+		require.NoError(t, err)
+		require.Len(t, networks, 1)
+
+		network := networks["test-mainnet"]
+		require.NotNil(t, network.Forks)
+		require.NotNil(t, network.Forks.Consensus)
+		require.Contains(t, network.Forks.Consensus, "electra")
+
+		electra := network.Forks.Consensus["electra"]
+		assert.Equal(t, uint64(364032), electra.Epoch)
+		assert.Equal(t, "7.0.0", electra.MinClientVersions["lighthouse"])
+		assert.Equal(t, "6.0.0", electra.MinClientVersions["prysm"])
+		assert.Equal(t, "25.4.1", electra.MinClientVersions["teku"])
+	})
+
+	t.Run("network without fork configuration", func(t *testing.T) {
+		config := discovery.Config{}
+		config.Static.Networks = []discovery.StaticNetworkConfig{
+			{
+				Name:        "test-network",
+				Description: "Test network without forks",
+				ChainID:     1000,
+				GenesisTime: 1700000000,
+				ServiceURLs: map[string]string{
+					"ethstats": "https://ethstats.test.io",
+				},
+				// No Forks field
+			},
+		}
+
+		networks, err := provider.Discover(context.Background(), config)
+		require.NoError(t, err)
+		require.Len(t, networks, 1)
+
+		network := networks["test-network"]
+		assert.Nil(t, network.Forks)
+	})
+
+	t.Run("fork config without minClientVersions", func(t *testing.T) {
+		config := discovery.Config{}
+		config.Static.Networks = []discovery.StaticNetworkConfig{
+			{
+				Name:        "test-holesky",
+				Description: "Test network with fork but no client versions",
+				ChainID:     17000,
+				GenesisTime: 1695902400,
+				ServiceURLs: map[string]string{
+					"ethstats": "https://ethstats.test.io",
+				},
+				Forks: &discovery.ForksConfig{
+					Consensus: map[string]discovery.ForkConfig{
+						"electra": {
+							Epoch: 0,
+							// No MinClientVersions - this is valid for future/unknown requirements
+						},
+					},
+				},
+			},
+		}
+
+		networks, err := provider.Discover(context.Background(), config)
+		require.NoError(t, err)
+		require.Len(t, networks, 1)
+
+		network := networks["test-holesky"]
+		require.NotNil(t, network.Forks)
+		require.NotNil(t, network.Forks.Consensus)
+		require.Contains(t, network.Forks.Consensus, "electra")
+
+		electra := network.Forks.Consensus["electra"]
+		assert.Equal(t, uint64(0), electra.Epoch)
+		assert.Nil(t, electra.MinClientVersions)
+	})
+
+	t.Run("multiple forks in same network", func(t *testing.T) {
+		config := discovery.Config{}
+		config.Static.Networks = []discovery.StaticNetworkConfig{
+			{
+				Name:        "test-multi-fork",
+				Description: "Test network with multiple forks",
+				ChainID:     2000,
+				GenesisTime: 1700000000,
+				ServiceURLs: map[string]string{
+					"ethstats": "https://ethstats.test.io",
+				},
+				Forks: &discovery.ForksConfig{
+					Consensus: map[string]discovery.ForkConfig{
+						"electra": {
+							Epoch: 100,
+							MinClientVersions: map[string]string{
+								"lighthouse": "7.0.0",
+							},
+						},
+						"fulu": {
+							Epoch: 200,
+							MinClientVersions: map[string]string{
+								"lighthouse": "8.0.0",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		networks, err := provider.Discover(context.Background(), config)
+		require.NoError(t, err)
+		require.Len(t, networks, 1)
+
+		network := networks["test-multi-fork"]
+		require.NotNil(t, network.Forks)
+		require.Len(t, network.Forks.Consensus, 2)
+
+		assert.Contains(t, network.Forks.Consensus, "electra")
+		assert.Contains(t, network.Forks.Consensus, "fulu")
+
+		assert.Equal(t, uint64(100), network.Forks.Consensus["electra"].Epoch)
+		assert.Equal(t, uint64(200), network.Forks.Consensus["fulu"].Epoch)
+	})
+}
+
 func TestProvider_Discover(t *testing.T) {
 	log := logrus.New()
 	provider, err := NewProvider(log)
 	require.NoError(t, err)
 
-	networks, err := provider.Discover(context.Background(), discovery.Config{})
+	// Create config with static networks
+	config := discovery.Config{}
+	config.Static.Networks = []discovery.StaticNetworkConfig{
+		{
+			Name:        "mainnet",
+			Description: "Production Ethereum network",
+			ChainID:     1,
+			GenesisTime: 1606824023,
+			ServiceURLs: map[string]string{
+				"ethstats":    "https://ethstats.mainnet.ethpandaops.io",
+				"forkmon":     "https://forkmon.mainnet.ethpandaops.io",
+				"blobArchive": "https://blob-archive.mainnet.ethpandaops.io",
+				"forky":       "https://forky.mainnet.ethpandaops.io",
+				"tracoor":     "https://tracoor.mainnet.ethpandaops.io",
+			},
+		},
+		{
+			Name:        "sepolia",
+			Description: "Smaller testnet for application development with controlled validator set.",
+			ChainID:     11155111,
+			GenesisTime: 1655726400,
+			ServiceURLs: map[string]string{
+				"dora":           "https://dora.sepolia.ethpandaops.io",
+				"beaconExplorer": "https://dora.sepolia.ethpandaops.io",
+				"checkpointSync": "https://checkpoint-sync.sepolia.ethpandaops.io",
+				"ethstats":       "https://ethstats.sepolia.ethpandaops.io",
+				"forkmon":        "https://forkmon.sepolia.ethpandaops.io",
+				"blobArchive":    "https://blob-archive.sepolia.ethpandaops.io",
+				"forky":          "https://forky.sepolia.ethpandaops.io",
+				"tracoor":        "https://tracoor.sepolia.ethpandaops.io",
+			},
+		},
+		{
+			Name:        "hoodi",
+			Description: "New public testnet (launched March 2025) designed for validator testing and protocol upgrades, replacing Holesky.",
+			ChainID:     560048,
+			GenesisTime: 1742213400,
+			ServiceURLs: map[string]string{
+				"dora":           "https://dora.hoodi.ethpandaops.io",
+				"beaconExplorer": "https://dora.hoodi.ethpandaops.io",
+				"checkpointSync": "https://checkpoint-sync.hoodi.ethpandaops.io",
+				"forkmon":        "https://forkmon.hoodi.ethpandaops.io",
+				"forky":          "https://forky.hoodi.ethpandaops.io",
+				"tracoor":        "https://tracoor.hoodi.ethpandaops.io",
+			},
+		},
+	}
+
+	networks, err := provider.Discover(context.Background(), config)
 	require.NoError(t, err)
 
 	// Verify we got the expected networks
-	assert.Len(t, networks, 4)
+	assert.Len(t, networks, 3)
 	assert.Contains(t, networks, "mainnet")
 	assert.Contains(t, networks, "sepolia")
 	assert.Contains(t, networks, "hoodi")
@@ -103,7 +385,6 @@ func TestProvider_Discover(t *testing.T) {
 	mainnet := networks["mainnet"]
 	assert.Equal(t, "mainnet", mainnet.Name)
 	assert.Equal(t, "Production Ethereum network", mainnet.Description)
-	assert.Equal(t, "active", mainnet.Status)
 	assert.WithinDuration(t, time.Now(), mainnet.LastUpdated, 10*time.Second)
 	require.NotNil(t, mainnet.ServiceURLs)
 	assert.Equal(t, "https://ethstats.mainnet.ethpandaops.io", mainnet.ServiceURLs.Ethstats)
@@ -116,7 +397,6 @@ func TestProvider_Discover(t *testing.T) {
 	sepolia := networks["sepolia"]
 	assert.Equal(t, "sepolia", sepolia.Name)
 	assert.Equal(t, "Smaller testnet for application development with controlled validator set.", sepolia.Description)
-	assert.Equal(t, "active", sepolia.Status)
 	assert.WithinDuration(t, time.Now(), sepolia.LastUpdated, 10*time.Second)
 	require.NotNil(t, sepolia.ServiceURLs)
 	assert.Equal(t, "https://dora.sepolia.ethpandaops.io", sepolia.ServiceURLs.Dora)
@@ -128,7 +408,6 @@ func TestProvider_Discover(t *testing.T) {
 	hoodi := networks["hoodi"]
 	assert.Equal(t, "hoodi", hoodi.Name)
 	assert.Equal(t, "New public testnet (launched March 2025) designed for validator testing and protocol upgrades, replacing Holesky.", hoodi.Description)
-	assert.Equal(t, "active", hoodi.Status)
 	assert.WithinDuration(t, time.Now(), hoodi.LastUpdated, 10*time.Second)
 	require.NotNil(t, hoodi.ServiceURLs)
 	assert.Equal(t, "https://dora.hoodi.ethpandaops.io", hoodi.ServiceURLs.Dora)


### PR DESCRIPTION
Replace the hard-coded network list in the static provider with a configuration-driven approach. This allows networks, their services and fork schedules to be updated without code changes.

Introduce StaticNetworkConfig and ForksConfig types so every network can declare its chain-id, genesis time, service URLs and upcoming forks with required client versions.