### PR TITLE
feat: add validator-ranges generation

### DIFF
--- a/.github/config.production.yaml
+++ b/.github/config.production.yaml
@@ -211,6 +211,31 @@ discovery:
     # GitHub API token (via environment variable)
     token: ${GITHUB_TOKEN}
 
+# Validator ranges configuration (optional)
+validatorRanges:
+  # Additional third-party validator sources
+  #
+  # Validator Range Distribution:
+  # On testnets, validators are typically distributed across multiple organizations.
+  # Each organization may number their validators locally starting from 0, but globally
+  # they're assigned specific ranges to avoid conflicts.
+  #
+  # Example for fusaka-devnet-5:
+  #   - ethpandaops:     0-50,912    (owned and operated by ethpandaops)
+  #   - Reserved:    50,913-51,311    (400 validators reserved for Prysm, not yet deployed)
+  #   - testinprod:  51,312-56,000    (assigned to testinprod/Sunny Side Labs)
+  #
+  # Since external organizations number their validators locally (e.g., testinprod uses 0-4,688),
+  # we need to apply an offset to map their local ranges to the global validator numbering.
+  #
+  # rangeOffset: The value to add to all validator_start and validator_end values from this source
+  #              to map them to their globally assigned range.
+  additionalSources:
+    fusaka-devnet-5:
+      - url: https://raw.githubusercontent.com/testinprod-io/fusaka-devnets/refs/heads/main/ansible/inventories/devnet-5/inventory.ini
+        name: testinprod
+        rangeOffset: 51312  # Maps testinprod's local 0-4688 to global 51312-56000
+
 # S3 storage configuration
 storage:
   # S3 bucket name - environment variable example: ${S3_BUCKET_NAME}

--- a/.github/workflows/cartographoor.yml
+++ b/.github/workflows/cartographoor.yml
@@ -1,4 +1,4 @@
-name: Cartographoor Network Discovery
+name: Network Generation
 
 on:
   schedule:
@@ -11,17 +11,17 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
-      
+
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
           go-version: '1.24'
           check-latest: true
-      
+
       - name: Build Cartographoor
         run: |
           go build -o cartographoor ./cmd/cartographoor
-      
+
       - name: Run Cartographoor
         run: |
           ./cartographoor run --config=.github/config.production.yaml
@@ -30,4 +30,4 @@ jobs:
           AWS_REGION: ${{ secrets.AWS_REGION }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          S3_BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }} 
+          S3_BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}

--- a/.github/workflows/validator-ranges.yml
+++ b/.github/workflows/validator-ranges.yml
@@ -1,8 +1,8 @@
-name: Inventory Generation
+name: Validator Ranges Generation
 
 on:
   schedule:
-    - cron: '*/15 * * * *'  # Every 15 minutes
+    - cron: '0 * * * *'  # Run every hour
   workflow_dispatch:  # Manual trigger
 
 jobs:
@@ -22,9 +22,9 @@ jobs:
         run: |
           go build -o cartographoor ./cmd/cartographoor
 
-      - name: Run Inventory Generation
+      - name: Run Validator Ranges Generation
         run: |
-          ./cartographoor inventory --config=.github/config.production.yaml
+          ./cartographoor validator-ranges --config=.github/config.production.yaml
         env:
           GITHUB_TOKEN: ${{ secrets.CARTOGRAPHOOR_GITHUB_TOKEN }}
           AWS_REGION: ${{ secrets.AWS_REGION }}

--- a/cmd/cartographoor/cmd/root.go
+++ b/cmd/cartographoor/cmd/root.go
@@ -15,6 +15,7 @@ func NewRootCommand(log *logrus.Logger) *cobra.Command {
 	// Add subcommands.
 	cmd.AddCommand(newRunCmd(log))
 	cmd.AddCommand(newInventoryCmd(log))
+	cmd.AddCommand(newValidatorRangesCmd(log))
 
 	return cmd
 }

--- a/cmd/cartographoor/cmd/run.go
+++ b/cmd/cartographoor/cmd/run.go
@@ -26,10 +26,22 @@ type runConfig struct {
 	Logging struct {
 		Level string `mapstructure:"level"`
 	} `mapstructure:"logging"`
-	ConfigFile string
-	Discovery  discovery.Config `mapstructure:"discovery"`
-	Storage    s3.Config        `mapstructure:"storage"`
-	RunOnce    bool             `mapstructure:"runOnce"`
+	ConfigFile      string
+	Discovery       discovery.Config       `mapstructure:"discovery"`
+	Storage         s3.Config              `mapstructure:"storage"`
+	RunOnce         bool                   `mapstructure:"runOnce"`
+	ValidatorRanges *ValidatorRangesConfig `mapstructure:"validatorRanges"`
+}
+
+// ValidatorRangesConfig holds configuration for validator ranges generation.
+type ValidatorRangesConfig struct {
+	AdditionalSources map[string][]ValidatorSource `mapstructure:"additionalSources"`
+}
+
+// ValidatorSource represents a single validator data source.
+type ValidatorSource struct {
+	URL  string `mapstructure:"url"`
+	Name string `mapstructure:"name"`
 }
 
 func newRunCmd(log *logrus.Logger) *cobra.Command {

--- a/cmd/cartographoor/cmd/validator_ranges.go
+++ b/cmd/cartographoor/cmd/validator_ranges.go
@@ -1,0 +1,143 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/ethpandaops/cartographoor/pkg/discovery"
+	"github.com/ethpandaops/cartographoor/pkg/storage/s3"
+	"github.com/ethpandaops/cartographoor/pkg/validatorranges"
+)
+
+type validatorRangesConfig struct {
+	Logging struct {
+		Level string `mapstructure:"level"`
+	} `mapstructure:"logging"`
+	ConfigFile      string
+	Storage         s3.Config               `mapstructure:"storage"`
+	ValidatorRanges *validatorranges.Config `mapstructure:"validatorRanges"`
+}
+
+func newValidatorRangesCmd(log *logrus.Logger) *cobra.Command {
+	cfg := &validatorRangesConfig{}
+
+	cmd := &cobra.Command{
+		Use:   "validator-ranges",
+		Short: "Generate validator ranges for discovered networks",
+		Long:  `Downloads networks.json and generates validator range data from Ansible inventory files`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := viper.New()
+
+			if cfg.ConfigFile != "" {
+				v.SetConfigFile(cfg.ConfigFile)
+
+				// Read and process the config file with environment variable substitution
+				if err := readConfigWithEnvSubst(v); err != nil {
+					return err
+				}
+			}
+
+			v.SetEnvPrefix("CARTOGRAPHOOR")
+			v.AutomaticEnv()
+
+			if err := v.Unmarshal(cfg); err != nil {
+				return err
+			}
+
+			// Set log level
+			level, err := logrus.ParseLevel(cfg.Logging.Level)
+			if err == nil {
+				log.SetLevel(level)
+			}
+
+			return runValidatorRanges(cmd.Context(), log, cfg)
+		},
+	}
+
+	// Define flags
+	cmd.Flags().StringVarP(&cfg.ConfigFile, "config", "c", "", "Path to config file")
+	cmd.Flags().StringVar(&cfg.Logging.Level, "logging.level", "info", "Logging level (trace, debug, info, warn, error, fatal, panic)")
+
+	// Mark config as required
+	if err := cmd.MarkFlagRequired("config"); err != nil {
+		log.WithError(err).Fatal("Failed to mark config flag as required")
+	}
+
+	return cmd
+}
+
+func runValidatorRanges(ctx context.Context, log *logrus.Logger, cfg *validatorRangesConfig) error {
+	// Set up context with cancellation
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// Handle signals for graceful shutdown
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
+
+	go func() {
+		<-sigChan
+		log.Info("Received shutdown signal, cancelling context")
+		cancel()
+	}()
+
+	// Create S3 storage provider
+	storageProvider, err := s3.NewProvider(log, cfg.Storage)
+	if err != nil {
+		return fmt.Errorf("failed to create S3 storage provider: %w", err)
+	}
+
+	// Initialize storage provider
+	if initErr := storageProvider.Initialize(ctx); initErr != nil {
+		return fmt.Errorf("failed to initialize storage provider: %w", initErr)
+	}
+
+	log.Info("Downloading networks.json from S3")
+
+	// Download networks.json from S3
+	networksData, err := storageProvider.Download(ctx, "networks.json")
+	if err != nil {
+		return fmt.Errorf("failed to download networks.json: %w", err)
+	}
+
+	// Parse networks.json
+	var discoveryResult discovery.Result
+	if err := json.Unmarshal(networksData, &discoveryResult); err != nil {
+		return fmt.Errorf("failed to parse networks.json: %w", err)
+	}
+
+	log.WithField("networks", len(discoveryResult.Networks)).Info("Downloaded networks from S3")
+
+	// Create validator ranges service
+	service := validatorranges.NewService(storageProvider, cfg.ValidatorRanges, log)
+
+	log.Info("Starting validator ranges generation")
+
+	// Process all active networks
+	activeNetworks := make(map[string]discovery.Network)
+
+	for name, network := range discoveryResult.Networks {
+		if network.Status == "active" || network.Status == "running" {
+			activeNetworks[name] = network
+		}
+	}
+
+	log.WithField("active_networks", len(activeNetworks)).Info("Processing active networks")
+
+	// Generate validator ranges for all networks
+	if err := service.GenerateValidatorRanges(ctx, activeNetworks); err != nil {
+		return fmt.Errorf("validator ranges generation failed: %w", err)
+	}
+
+	log.Info("Validator ranges generation completed successfully")
+
+	return nil
+}

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -65,3 +65,28 @@ storage:
   retryDuration: 5s
   maxRetries: 3
   backoffJitterPercent: 20
+
+# Validator ranges configuration (optional)
+validatorRanges:
+  # Additional third-party validator sources
+  # 
+  # Validator Range Distribution:
+  # On testnets, validators are typically distributed across multiple organizations.
+  # Each organization may number their validators locally starting from 0, but globally
+  # they're assigned specific ranges to avoid conflicts.
+  #
+  # Example for fusaka-devnet-5:
+  #   - ethpandaops:     0-50,912    (owned and operated by ethpandaops)
+  #   - Reserved:    50,913-51,311    (400 validators reserved for Prysm, not yet deployed)
+  #   - testinprod:  51,312-56,000    (assigned to testinprod/Sunny Side Labs)
+  #
+  # Since external organizations number their validators locally (e.g., testinprod uses 0-4,688),
+  # we need to apply an offset to map their local ranges to the global validator numbering.
+  #
+  # rangeOffset: The value to add to all validator_start and validator_end values from this source
+  #              to map them to their globally assigned range.
+  additionalSources:
+    fusaka-devnet-5:
+      - url: https://raw.githubusercontent.com/testinprod-io/fusaka-devnets/refs/heads/main/ansible/inventories/devnet-5/inventory.ini
+        name: testinprod
+        rangeOffset: 51312  # Maps testinprod's local 0-4688 to global 51312-56000

--- a/go.mod
+++ b/go.mod
@@ -100,5 +100,6 @@ require (
 	golang.org/x/text v0.25.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250721164621-a45f3dfb1074 // indirect
 	google.golang.org/protobuf v1.36.6 // indirect
+	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -264,6 +264,8 @@ google.golang.org/protobuf v1.36.6/go.mod h1:jduwjTPXsFjZGTmRluh+L6NjiWu7pchiJ2/
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
+gopkg.in/ini.v1 v1.67.0 h1:Dgnx+6+nfE+IfzjUEISNeydPJh9AXNNsWbGP9KzCsOA=
+gopkg.in/ini.v1 v1.67.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/validatorranges/aggregator.go
+++ b/pkg/validatorranges/aggregator.go
@@ -1,0 +1,120 @@
+package validatorranges
+
+import (
+	"github.com/sirupsen/logrus"
+)
+
+// AggregateRanges combines multiple ValidatorRanges into a single consolidated result.
+func AggregateRanges(ranges []*ValidatorRanges) *ValidatorRanges {
+	if len(ranges) == 0 {
+		return &ValidatorRanges{
+			Nodes:      make(map[string]*Node),
+			Validators: &ValidatorSummary{TotalCount: 0},
+			Groups:     make(map[string][]string),
+			Tags:       make(map[string][]string),
+			Metadata:   &Metadata{Sources: []string{}},
+		}
+	}
+
+	// Start with an empty result
+	result := &ValidatorRanges{
+		Nodes:      make(map[string]*Node),
+		Validators: &ValidatorSummary{TotalCount: 0},
+		Groups:     make(map[string][]string),
+		Tags:       make(map[string][]string),
+		Metadata:   &Metadata{Sources: []string{}},
+	}
+
+	// Aggregate all ranges
+	for _, vr := range ranges {
+		if vr == nil {
+			continue
+		}
+
+		// Merge nodes
+		mergeNodes(result.Nodes, vr.Nodes)
+
+		// Aggregate sources
+		if vr.Metadata != nil {
+			result.Metadata.Sources = append(result.Metadata.Sources, vr.Metadata.Sources...)
+		}
+	}
+
+	// Rebuild groups and tags from the final merged nodes (after duplicates have been skipped)
+	result.Groups, result.Tags = buildGroupsAndTags(result.Nodes)
+
+	// Deduplicate sources
+	result.Metadata.Sources = deduplicateSlice(result.Metadata.Sources)
+
+	// Recalculate totals
+	recalculateTotals(result)
+
+	return result
+}
+
+// mergeNodes adds source nodes into target nodes map, logging and skipping duplicates.
+func mergeNodes(target, source map[string]*Node) {
+	logger := logrus.WithField("module", "validator_ranges_aggregator")
+
+	for name, node := range source {
+		if existingNode, exists := target[name]; exists {
+			// Log warning about duplicate node and skip it
+			logger.WithFields(logrus.Fields{
+				"node":             name,
+				"existing_source":  existingNode.Source,
+				"duplicate_source": node.Source,
+			}).Warn("Duplicate node name found, skipping - this may indicate a configuration issue")
+
+			continue
+		}
+
+		// Deep copy the node
+		newNode := &Node{
+			Groups:          make([]string, len(node.Groups)),
+			Tags:            make([]string, len(node.Tags)),
+			Attributes:      make(map[string]interface{}),
+			ValidatorRanges: make([]*ValidatorRange, len(node.ValidatorRanges)),
+			Source:          node.Source,
+		}
+
+		copy(newNode.Groups, node.Groups)
+		copy(newNode.Tags, node.Tags)
+		copy(newNode.ValidatorRanges, node.ValidatorRanges)
+
+		for k, v := range node.Attributes {
+			newNode.Attributes[k] = v
+		}
+
+		target[name] = newNode
+	}
+}
+
+// recalculateTotals recalculates the total validator count.
+func recalculateTotals(vr *ValidatorRanges) {
+	total := 0
+
+	for _, node := range vr.Nodes {
+		for _, vRange := range node.ValidatorRanges {
+			if vRange != nil {
+				total += vRange.End - vRange.Start
+			}
+		}
+	}
+
+	vr.Validators.TotalCount = total
+}
+
+// deduplicateSlice removes duplicate strings from a slice.
+func deduplicateSlice(slice []string) []string {
+	seen := make(map[string]bool, len(slice))
+	result := make([]string, 0, len(slice))
+
+	for _, s := range slice {
+		if !seen[s] {
+			seen[s] = true
+			result = append(result, s)
+		}
+	}
+
+	return result
+}

--- a/pkg/validatorranges/aggregator_test.go
+++ b/pkg/validatorranges/aggregator_test.go
@@ -1,0 +1,467 @@
+package validatorranges
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestAggregateRanges(t *testing.T) {
+	tests := []struct {
+		name   string
+		ranges []*ValidatorRanges
+		want   *ValidatorRanges
+	}{
+		{
+			name: "aggregate multiple sources",
+			ranges: []*ValidatorRanges{
+				{
+					Nodes: map[string]*Node{
+						"lighthouse-geth-1": {
+							Groups: []string{"lighthouse_geth"},
+							Tags:   []string{"el:geth", "cl:lighthouse"},
+							Attributes: map[string]interface{}{
+								"cloud": "aws",
+							},
+							ValidatorRanges: []*ValidatorRange{
+								{Start: 0, End: 8},
+							},
+							Source: "ethpandaops",
+						},
+						"prysm-besu-1": {
+							Groups: []string{"prysm_besu"},
+							Tags:   []string{"el:besu", "cl:prysm"},
+							Attributes: map[string]interface{}{
+								"region": "us-east-1",
+							},
+							ValidatorRanges: []*ValidatorRange{
+								{Start: 100, End: 108},
+							},
+							Source: "ethpandaops",
+						},
+					},
+					Validators: &ValidatorSummary{TotalCount: 16},
+					Groups: map[string][]string{
+						"lighthouse_geth": {"lighthouse-geth-1"},
+						"prysm_besu":      {"prysm-besu-1"},
+					},
+					Tags: map[string][]string{
+						"el:geth":       {"lighthouse-geth-1"},
+						"cl:lighthouse": {"lighthouse-geth-1"},
+						"el:besu":       {"prysm-besu-1"},
+						"cl:prysm":      {"prysm-besu-1"},
+					},
+					Metadata: &Metadata{
+						Sources: []string{"https://ethpandaops.com/inventory.ini"},
+					},
+				},
+				{
+					Nodes: map[string]*Node{
+						"lighthouse-besu-1": {
+							Groups: []string{"lighthouse_besu"},
+							Tags:   []string{"el:besu", "cl:lighthouse"},
+							Attributes: map[string]interface{}{
+								"cloud": "digitalocean",
+							},
+							ValidatorRanges: []*ValidatorRange{
+								{Start: 51312, End: 51320},
+							},
+							Source: "testinprod",
+						},
+						"teku-geth-1": {
+							Groups: []string{"teku_geth"},
+							Tags:   []string{"el:geth", "cl:teku"},
+							Attributes: map[string]interface{}{
+								"isClSupernode": true,
+							},
+							ValidatorRanges: []*ValidatorRange{
+								{Start: 51400, End: 51408},
+							},
+							Source: "testinprod",
+						},
+					},
+					Validators: &ValidatorSummary{TotalCount: 16},
+					Groups: map[string][]string{
+						"lighthouse_besu": {"lighthouse-besu-1"},
+						"teku_geth":       {"teku-geth-1"},
+					},
+					Tags: map[string][]string{
+						"el:besu":       {"lighthouse-besu-1"},
+						"cl:lighthouse": {"lighthouse-besu-1"},
+						"el:geth":       {"teku-geth-1"},
+						"cl:teku":       {"teku-geth-1"},
+					},
+					Metadata: &Metadata{
+						Sources: []string{"https://testinprod.com/inventory.ini"},
+					},
+				},
+			},
+			want: &ValidatorRanges{
+				Nodes: map[string]*Node{
+					"lighthouse-geth-1": {
+						Groups: []string{"lighthouse_geth"},
+						Tags:   []string{"el:geth", "cl:lighthouse"},
+						Attributes: map[string]interface{}{
+							"cloud": "aws",
+						},
+						ValidatorRanges: []*ValidatorRange{
+							{Start: 0, End: 8},
+						},
+						Source: "ethpandaops",
+					},
+					"prysm-besu-1": {
+						Groups: []string{"prysm_besu"},
+						Tags:   []string{"el:besu", "cl:prysm"},
+						Attributes: map[string]interface{}{
+							"region": "us-east-1",
+						},
+						ValidatorRanges: []*ValidatorRange{
+							{Start: 100, End: 108},
+						},
+						Source: "ethpandaops",
+					},
+					"lighthouse-besu-1": {
+						Groups: []string{"lighthouse_besu"},
+						Tags:   []string{"el:besu", "cl:lighthouse"},
+						Attributes: map[string]interface{}{
+							"cloud": "digitalocean",
+						},
+						ValidatorRanges: []*ValidatorRange{
+							{Start: 51312, End: 51320},
+						},
+						Source: "testinprod",
+					},
+					"teku-geth-1": {
+						Groups: []string{"teku_geth"},
+						Tags:   []string{"el:geth", "cl:teku"},
+						Attributes: map[string]interface{}{
+							"isClSupernode": true,
+						},
+						ValidatorRanges: []*ValidatorRange{
+							{Start: 51400, End: 51408},
+						},
+						Source: "testinprod",
+					},
+				},
+				Validators: &ValidatorSummary{
+					TotalCount: 32, // 8 + 8 + 8 + 8
+				},
+				Groups: map[string][]string{
+					"lighthouse_geth": {"lighthouse-geth-1"},
+					"prysm_besu":      {"prysm-besu-1"},
+					"lighthouse_besu": {"lighthouse-besu-1"},
+					"teku_geth":       {"teku-geth-1"},
+				},
+				Tags: map[string][]string{
+					"el:geth":       {"lighthouse-geth-1", "teku-geth-1"},
+					"cl:lighthouse": {"lighthouse-geth-1", "lighthouse-besu-1"},
+					"el:besu":       {"prysm-besu-1", "lighthouse-besu-1"},
+					"cl:prysm":      {"prysm-besu-1"},
+					"cl:teku":       {"teku-geth-1"},
+				},
+				Metadata: &Metadata{
+					Sources: []string{"https://ethpandaops.com/inventory.ini", "https://testinprod.com/inventory.ini"},
+				},
+			},
+		},
+		{
+			name: "duplicate nodes are skipped not merged",
+			ranges: []*ValidatorRanges{
+				{
+					Nodes: map[string]*Node{
+						"lighthouse-geth-1": {
+							Groups: []string{"lighthouse_geth"},
+							Tags:   []string{"el:geth", "cl:lighthouse"},
+							Attributes: map[string]interface{}{
+								"cloud": "aws",
+							},
+							ValidatorRanges: []*ValidatorRange{
+								{Start: 0, End: 8},
+							},
+							Source: "ethpandaops",
+						},
+					},
+					Validators: &ValidatorSummary{TotalCount: 8},
+					Groups: map[string][]string{
+						"lighthouse_geth": {"lighthouse-geth-1"},
+					},
+					Tags: map[string][]string{
+						"el:geth":       {"lighthouse-geth-1"},
+						"cl:lighthouse": {"lighthouse-geth-1"},
+					},
+					Metadata: &Metadata{
+						Sources: []string{"https://source1.com/inventory.ini"},
+					},
+				},
+				{
+					Nodes: map[string]*Node{
+						"lighthouse-geth-1": {
+							Groups: []string{"lighthouse_geth", "validators"},
+							Tags:   []string{"el:geth", "cl:lighthouse", "vc:validator"},
+							Attributes: map[string]interface{}{
+								"cloud":  "digitalocean",
+								"region": "nyc1",
+							},
+							ValidatorRanges: []*ValidatorRange{
+								{Start: 51312, End: 51320},
+							},
+							Source: "testinprod", // Different source - should be skipped
+						},
+						"lighthouse-geth-2": {
+							Groups: []string{"lighthouse_geth"},
+							Tags:   []string{"el:geth", "cl:lighthouse"},
+							Attributes: map[string]interface{}{
+								"cloud": "digitalocean",
+							},
+							ValidatorRanges: []*ValidatorRange{
+								{Start: 51320, End: 51328},
+							},
+							Source: "testinprod",
+						},
+					},
+					Validators: &ValidatorSummary{TotalCount: 16},
+					Groups: map[string][]string{
+						"lighthouse_geth": {"lighthouse-geth-1", "lighthouse-geth-2"},
+						"validators":      {"lighthouse-geth-1"},
+					},
+					Tags: map[string][]string{
+						"el:geth":       {"lighthouse-geth-1", "lighthouse-geth-2"},
+						"cl:lighthouse": {"lighthouse-geth-1", "lighthouse-geth-2"},
+						"vc:validator":  {"lighthouse-geth-1"},
+					},
+					Metadata: &Metadata{
+						Sources: []string{"https://source2.com/inventory.ini"},
+					},
+				},
+			},
+			want: &ValidatorRanges{
+				Nodes: map[string]*Node{
+					"lighthouse-geth-1": {
+						Groups: []string{"lighthouse_geth"},
+						Tags:   []string{"el:geth", "cl:lighthouse"},
+						Attributes: map[string]interface{}{
+							"cloud": "aws",
+						},
+						ValidatorRanges: []*ValidatorRange{
+							{Start: 0, End: 8},
+						},
+						Source: "ethpandaops", // First one wins, duplicate is skipped
+					},
+					"lighthouse-geth-2": {
+						Groups: []string{"lighthouse_geth"},
+						Tags:   []string{"el:geth", "cl:lighthouse"},
+						Attributes: map[string]interface{}{
+							"cloud": "digitalocean",
+						},
+						ValidatorRanges: []*ValidatorRange{
+							{Start: 51320, End: 51328},
+						},
+						Source: "testinprod",
+					},
+				},
+				Validators: &ValidatorSummary{
+					TotalCount: 16, // 8 + 8 (duplicate lighthouse-geth-1 from testinprod is skipped)
+				},
+				Groups: map[string][]string{
+					"lighthouse_geth": {"lighthouse-geth-1", "lighthouse-geth-2"},
+					// Note: "validators" group is NOT included because the duplicate node with that group was skipped
+				},
+				Tags: map[string][]string{
+					"el:geth":       {"lighthouse-geth-1", "lighthouse-geth-2"},
+					"cl:lighthouse": {"lighthouse-geth-1", "lighthouse-geth-2"},
+					// Note: "vc:validator" tag is NOT included because the duplicate node with that tag was skipped
+				},
+				Metadata: &Metadata{
+					Sources: []string{"https://source1.com/inventory.ini", "https://source2.com/inventory.ini"},
+				},
+			},
+		},
+		{
+			name:   "empty ranges",
+			ranges: []*ValidatorRanges{},
+			want: &ValidatorRanges{
+				Nodes:      make(map[string]*Node),
+				Validators: &ValidatorSummary{TotalCount: 0},
+				Groups:     make(map[string][]string),
+				Tags:       make(map[string][]string),
+				Metadata:   &Metadata{Sources: []string{}},
+			},
+		},
+		{
+			name: "nil ranges in input",
+			ranges: []*ValidatorRanges{
+				{
+					Nodes: map[string]*Node{
+						"node1": {
+							Groups: []string{"group1"},
+							Tags:   []string{"tag1"},
+							Attributes: map[string]interface{}{
+								"attr": "value",
+							},
+							ValidatorRanges: []*ValidatorRange{
+								{Start: 0, End: 8},
+							},
+							Source: "source1",
+						},
+					},
+					Validators: &ValidatorSummary{TotalCount: 8},
+					Groups: map[string][]string{
+						"group1": {"node1"},
+					},
+					Tags: map[string][]string{
+						"tag1": {"node1"},
+					},
+					Metadata: &Metadata{
+						Sources: []string{"https://source1.com"},
+					},
+				},
+				nil, // nil entry should be handled gracefully
+				{
+					Nodes: map[string]*Node{
+						"node2": {
+							Groups: []string{"group2"},
+							Tags:   []string{"tag2"},
+							Attributes: map[string]interface{}{
+								"attr2": "value2",
+							},
+							ValidatorRanges: []*ValidatorRange{
+								{Start: 100, End: 108},
+							},
+							Source: "source2",
+						},
+					},
+					Validators: &ValidatorSummary{TotalCount: 8},
+					Groups: map[string][]string{
+						"group2": {"node2"},
+					},
+					Tags: map[string][]string{
+						"tag2": {"node2"},
+					},
+					Metadata: &Metadata{
+						Sources: []string{"https://source2.com"},
+					},
+				},
+			},
+			want: &ValidatorRanges{
+				Nodes: map[string]*Node{
+					"node1": {
+						Groups: []string{"group1"},
+						Tags:   []string{"tag1"},
+						Attributes: map[string]interface{}{
+							"attr": "value",
+						},
+						ValidatorRanges: []*ValidatorRange{
+							{Start: 0, End: 8},
+						},
+						Source: "source1",
+					},
+					"node2": {
+						Groups: []string{"group2"},
+						Tags:   []string{"tag2"},
+						Attributes: map[string]interface{}{
+							"attr2": "value2",
+						},
+						ValidatorRanges: []*ValidatorRange{
+							{Start: 100, End: 108},
+						},
+						Source: "source2",
+					},
+				},
+				Validators: &ValidatorSummary{
+					TotalCount: 16, // 8 + 8
+				},
+				Groups: map[string][]string{
+					"group1": {"node1"},
+					"group2": {"node2"},
+				},
+				Tags: map[string][]string{
+					"tag1": {"node1"},
+					"tag2": {"node2"},
+				},
+				Metadata: &Metadata{
+					Sources: []string{"https://source1.com", "https://source2.com"},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := AggregateRanges(tt.ranges)
+
+			// Check nodes
+			if !reflect.DeepEqual(got.Nodes, tt.want.Nodes) {
+				for name, node := range got.Nodes {
+					if wantNode, exists := tt.want.Nodes[name]; exists {
+						if !reflect.DeepEqual(node, wantNode) {
+							t.Errorf("Node %s mismatch:\ngot  %+v\nwant %+v", name, node, wantNode)
+						}
+					} else {
+						t.Errorf("Unexpected node: %s", name)
+					}
+				}
+				for name := range tt.want.Nodes {
+					if _, exists := got.Nodes[name]; !exists {
+						t.Errorf("Missing node: %s", name)
+					}
+				}
+			}
+
+			// Check validators
+			if got.Validators.TotalCount != tt.want.Validators.TotalCount {
+				t.Errorf("TotalCount = %v, want %v", got.Validators.TotalCount, tt.want.Validators.TotalCount)
+			}
+
+			// Check groups - compare each group's nodes without caring about order
+			if len(got.Groups) != len(tt.want.Groups) {
+				t.Errorf("Groups count mismatch: got %d, want %d", len(got.Groups), len(tt.want.Groups))
+			}
+			for group, nodes := range tt.want.Groups {
+				if gotNodes, exists := got.Groups[group]; exists {
+					if !slicesContainSameElements(gotNodes, nodes) {
+						t.Errorf("Group %s nodes mismatch:\ngot  %+v\nwant %+v", group, gotNodes, nodes)
+					}
+				} else {
+					t.Errorf("Missing group: %s", group)
+				}
+			}
+
+			// Check tags - tags may have different order in slices
+			if len(got.Tags) != len(tt.want.Tags) {
+				t.Errorf("Tags count mismatch: got %d, want %d", len(got.Tags), len(tt.want.Tags))
+			}
+			for tag, nodes := range tt.want.Tags {
+				if gotNodes, exists := got.Tags[tag]; exists {
+					if !slicesContainSameElements(gotNodes, nodes) {
+						t.Errorf("Tag %s nodes mismatch:\ngot  %+v\nwant %+v", tag, gotNodes, nodes)
+					}
+				} else {
+					t.Errorf("Missing tag: %s", tag)
+				}
+			}
+
+			// Check metadata
+			if !slicesContainSameElements(got.Metadata.Sources, tt.want.Metadata.Sources) {
+				t.Errorf("Sources mismatch:\ngot  %+v\nwant %+v", got.Metadata.Sources, tt.want.Metadata.Sources)
+			}
+		})
+	}
+}
+
+// slicesContainSameElements checks if two slices contain the same elements regardless of order.
+func slicesContainSameElements(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	aMap := make(map[string]int)
+	for _, s := range a {
+		aMap[s]++
+	}
+
+	bMap := make(map[string]int)
+	for _, s := range b {
+		bMap[s]++
+	}
+
+	return reflect.DeepEqual(aMap, bMap)
+}

--- a/pkg/validatorranges/fetcher.go
+++ b/pkg/validatorranges/fetcher.go
@@ -1,0 +1,81 @@
+package validatorranges
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// Fetcher handles downloading inventory files from GitHub.
+type Fetcher struct {
+	httpClient *http.Client
+}
+
+// NewFetcher creates a new Fetcher instance.
+func NewFetcher() *Fetcher {
+	return &Fetcher{
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}
+}
+
+// FetchInventoryFile downloads a single inventory file from a URL.
+func (f *Fetcher) FetchInventoryFile(ctx context.Context, url string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := f.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch inventory: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	return data, nil
+}
+
+// BuildInventoryURLs constructs URLs for standard inventory files for a network.
+func (f *Fetcher) BuildInventoryURLs(repo, network string) []string {
+	baseURL := fmt.Sprintf("https://raw.githubusercontent.com/%s/master/ansible/inventories/%s", repo, network)
+
+	return []string{
+		fmt.Sprintf("%s/inventory.ini", baseURL),
+		fmt.Sprintf("%s/hetzner_inventory.ini", baseURL),
+	}
+}
+
+// FetchMultiple fetches inventory files from multiple URLs, returning the content and successful URLs.
+func (f *Fetcher) FetchMultiple(ctx context.Context, urls []string) ([][]byte, []string, error) {
+	contents := make([][]byte, 0, len(urls))
+	successfulURLs := make([]string, 0, len(urls))
+
+	for _, url := range urls {
+		data, err := f.FetchInventoryFile(ctx, url)
+		if err != nil {
+			// Skip failed fetches (e.g., file doesn't exist)
+			continue
+		}
+
+		contents = append(contents, data)
+		successfulURLs = append(successfulURLs, url)
+	}
+
+	if len(contents) == 0 {
+		return nil, nil, fmt.Errorf("no inventory files could be fetched")
+	}
+
+	return contents, successfulURLs, nil
+}

--- a/pkg/validatorranges/parser.go
+++ b/pkg/validatorranges/parser.go
@@ -1,0 +1,330 @@
+package validatorranges
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"gopkg.in/ini.v1"
+)
+
+// ParseInventory parses an Ansible inventory INI file and extracts validator ranges.
+func ParseInventory(content []byte, sourceURL string, sourceName string, rangeOffset int) (*ValidatorRanges, error) {
+	// Pre-process content to remove standalone host entries like "localhost"
+	// which are valid Ansible but not valid INI format
+	lines := strings.Split(string(content), "\n")
+	processedLines := make([]string, 0, len(lines))
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		// Skip standalone host entries (lines without '=' that aren't sections)
+		if trimmed != "" && !strings.HasPrefix(trimmed, "[") && !strings.Contains(trimmed, "=") {
+			continue
+		}
+
+		processedLines = append(processedLines, line)
+	}
+
+	processedContent := strings.Join(processedLines, "\n")
+
+	cfg, err := ini.Load([]byte(processedContent))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse INI: %w", err)
+	}
+
+	nodes := make(map[string]*Node)
+
+	// Parse all sections except DEFAULT
+	for _, section := range cfg.Sections() {
+		if section.Name() == "DEFAULT" {
+			continue
+		}
+
+		parseSection(section, nodes, sourceName, rangeOffset)
+	}
+
+	// Filter out nodes without validator ranges
+	nodesWithValidators := make(map[string]*Node)
+
+	for name, node := range nodes {
+		if len(node.ValidatorRanges) > 0 {
+			nodesWithValidators[name] = node
+		}
+	}
+
+	// Build groups and tags from nodes with validators only
+	groups, tags := buildGroupsAndTags(nodesWithValidators)
+
+	// Calculate total validators
+	totalValidators := calculateTotalValidators(nodesWithValidators)
+
+	return &ValidatorRanges{
+		Nodes: nodesWithValidators,
+		Validators: &ValidatorSummary{
+			TotalCount: totalValidators,
+		},
+		Groups: groups,
+		Tags:   tags,
+		Metadata: &Metadata{
+			Sources: []string{sourceURL},
+		},
+	}, nil
+}
+
+// parseSection processes a single INI section and updates the nodes map.
+func parseSection(section *ini.Section, nodes map[string]*Node, sourceName string, rangeOffset int) {
+	sectionName := section.Name()
+
+	// Extract group and tags from section name
+	groupName := sectionName
+	sectionTags := extractTags([]string{groupName})
+
+	// Parse each key in the section
+	for _, key := range section.Keys() {
+		// Extract just the hostname (first part before space)
+		keyName := key.Name()
+		nodeName := keyName
+
+		if idx := strings.Index(keyName, " "); idx > 0 {
+			nodeName = keyName[:idx]
+		}
+
+		// Get or create the node
+		node, exists := nodes[nodeName]
+		if !exists {
+			node = &Node{
+				Groups:     []string{},
+				Tags:       []string{},
+				Attributes: make(map[string]interface{}),
+				Source:     sourceName,
+			}
+			nodes[nodeName] = node
+		}
+
+		// Add group to node
+		if !contains(node.Groups, groupName) {
+			node.Groups = append(node.Groups, groupName)
+		}
+
+		// Add tags to node
+		for _, tag := range sectionTags {
+			if !contains(node.Tags, tag) {
+				node.Tags = append(node.Tags, tag)
+			}
+		}
+
+		// Extract validator range from key value
+		if key.Value() != "" {
+			validatorRange := extractValidatorRange(key, rangeOffset)
+			if validatorRange != nil {
+				// Initialize array if needed
+				if node.ValidatorRanges == nil {
+					node.ValidatorRanges = []*ValidatorRange{}
+				}
+
+				node.ValidatorRanges = append(node.ValidatorRanges, validatorRange)
+			}
+
+			// Store all attributes with camelCase keys (excluding validator_start/end)
+			for _, attr := range strings.Fields(key.Value()) {
+				if strings.Contains(attr, "=") {
+					parts := strings.SplitN(attr, "=", 2)
+					if len(parts) == 2 {
+						// Skip validator_start and validator_end as they're in validatorRange
+						if parts[0] == "validator_start" || parts[0] == "validator_end" {
+							continue
+						}
+
+						camelKey := snakeToCamel(parts[0])
+
+						// Special case: rename long attribute names
+						if camelKey == "ethereumNodeClSupernodeEnabled" {
+							camelKey = "isClSupernode"
+						}
+
+						// Parse boolean values
+						value := parts[1]
+						switch strings.ToLower(value) {
+						case "true":
+							node.Attributes[camelKey] = true
+						case "false":
+							node.Attributes[camelKey] = false
+						default:
+							node.Attributes[camelKey] = value
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+// extractValidatorRange extracts validator start and end from a key value.
+func extractValidatorRange(key *ini.Key, rangeOffset int) *ValidatorRange {
+	value := key.Value()
+
+	var start, end int
+
+	var hasStart, hasEnd bool
+
+	// Parse attributes in the value
+	for _, attr := range strings.Fields(value) {
+		if strings.HasPrefix(attr, "validator_start=") {
+			parts := strings.Split(attr, "=")
+			if len(parts) == 2 {
+				if val, err := strconv.Atoi(parts[1]); err == nil {
+					start = val + rangeOffset
+					hasStart = true
+				}
+			}
+		} else if strings.HasPrefix(attr, "validator_end=") {
+			parts := strings.Split(attr, "=")
+			if len(parts) == 2 {
+				if val, err := strconv.Atoi(parts[1]); err == nil {
+					end = val + rangeOffset
+					hasEnd = true
+				}
+			}
+		}
+	}
+
+	if hasStart && hasEnd && end >= start {
+		return &ValidatorRange{
+			Start: start,
+			End:   end,
+		}
+	}
+
+	return nil
+}
+
+// extractTags extracts tags from group names.
+func extractTags(groups []string) []string {
+	tags := []string{}
+
+	for _, group := range groups {
+		// Check for execution layer tags
+		if strings.Contains(group, "besu") {
+			tags = append(tags, "el:besu")
+		}
+
+		if strings.Contains(group, "geth") {
+			tags = append(tags, "el:geth")
+		}
+
+		if strings.Contains(group, "nethermind") {
+			tags = append(tags, "el:nethermind")
+		}
+
+		if strings.Contains(group, "erigon") {
+			tags = append(tags, "el:erigon")
+		}
+
+		if strings.Contains(group, "reth") {
+			tags = append(tags, "el:reth")
+		}
+
+		// Check for consensus layer tags
+		if strings.Contains(group, "lighthouse") {
+			tags = append(tags, "cl:lighthouse")
+		}
+
+		if strings.Contains(group, "prysm") {
+			tags = append(tags, "cl:prysm")
+		}
+
+		if strings.Contains(group, "teku") {
+			tags = append(tags, "cl:teku")
+		}
+
+		if strings.Contains(group, "nimbus") {
+			tags = append(tags, "cl:nimbus")
+		}
+
+		if strings.Contains(group, "lodestar") {
+			tags = append(tags, "cl:lodestar")
+		}
+
+		if strings.Contains(group, "grandine") {
+			tags = append(tags, "cl:grandine")
+		}
+
+		// Check for validator client tags
+		if strings.Contains(group, "validator") {
+			tags = append(tags, "vc:validator")
+		}
+	}
+
+	return tags
+}
+
+// buildGroupsAndTags builds the groups and tags maps from nodes.
+func buildGroupsAndTags(nodes map[string]*Node) (map[string][]string, map[string][]string) {
+	groups := make(map[string][]string)
+	tags := make(map[string][]string)
+
+	for nodeName, node := range nodes {
+		// Build groups map
+		for _, group := range node.Groups {
+			if _, exists := groups[group]; !exists {
+				groups[group] = []string{}
+			}
+
+			groups[group] = append(groups[group], nodeName)
+		}
+
+		// Build tags map
+		for _, tag := range node.Tags {
+			if _, exists := tags[tag]; !exists {
+				tags[tag] = []string{}
+			}
+
+			tags[tag] = append(tags[tag], nodeName)
+		}
+	}
+
+	return groups, tags
+}
+
+// calculateTotalValidators calculates the total number of validators across all nodes.
+func calculateTotalValidators(nodes map[string]*Node) int {
+	total := 0
+
+	for _, node := range nodes {
+		for _, vRange := range node.ValidatorRanges {
+			if vRange != nil {
+				total += vRange.End - vRange.Start
+			}
+		}
+	}
+
+	return total
+}
+
+// contains checks if a string slice contains a specific string.
+func contains(slice []string, str string) bool {
+	for _, s := range slice {
+		if s == str {
+			return true
+		}
+	}
+
+	return false
+}
+
+// snakeToCamel converts snake_case to camelCase.
+func snakeToCamel(s string) string {
+	parts := strings.Split(s, "_")
+	if len(parts) == 0 {
+		return s
+	}
+
+	result := parts[0]
+	for i := 1; i < len(parts); i++ {
+		if len(parts[i]) > 0 {
+			result += strings.ToUpper(parts[i][:1]) + parts[i][1:]
+		}
+	}
+
+	return result
+}

--- a/pkg/validatorranges/parser_test.go
+++ b/pkg/validatorranges/parser_test.go
@@ -1,0 +1,521 @@
+package validatorranges
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseInventory(t *testing.T) {
+	tests := []struct {
+		name        string
+		content     string
+		sourceURL   string
+		sourceName  string
+		rangeOffset int
+		want        *ValidatorRanges
+		wantErr     bool
+	}{
+		{
+			name: "basic ethpandaops inventory without offset",
+			content: `[lighthouse_geth]
+lighthouse-geth-1 ansible_host=192.168.1.1 validator_start=100 validator_end=108 cloud=aws cloud_region=us-east-1
+lighthouse-geth-2 ansible_host=192.168.1.2 validator_start=108 validator_end=116 cloud=aws cloud_region=us-west-2
+
+[prysm_nethermind]
+prysm-nethermind-1 ansible_host=192.168.1.3 validator_start=200 validator_end=208 ipv6=2001:db8::1
+`,
+			sourceURL:   "https://example.com/inventory.ini",
+			sourceName:  "ethpandaops",
+			rangeOffset: 0,
+			want: &ValidatorRanges{
+				Nodes: map[string]*Node{
+					"lighthouse-geth-1": {
+						Groups: []string{"lighthouse_geth"},
+						Tags:   []string{"el:geth", "cl:lighthouse"},
+						Attributes: map[string]interface{}{
+							"cloud":       "aws",
+							"cloudRegion": "us-east-1",
+						},
+						ValidatorRanges: []*ValidatorRange{
+							{Start: 100, End: 108},
+						},
+						Source: "ethpandaops",
+					},
+					"lighthouse-geth-2": {
+						Groups: []string{"lighthouse_geth"},
+						Tags:   []string{"el:geth", "cl:lighthouse"},
+						Attributes: map[string]interface{}{
+							"cloud":       "aws",
+							"cloudRegion": "us-west-2",
+						},
+						ValidatorRanges: []*ValidatorRange{
+							{Start: 108, End: 116},
+						},
+						Source: "ethpandaops",
+					},
+					"prysm-nethermind-1": {
+						Groups: []string{"prysm_nethermind"},
+						Tags:   []string{"el:nethermind", "cl:prysm"},
+						Attributes: map[string]interface{}{
+							"ipv6": "2001:db8::1",
+						},
+						ValidatorRanges: []*ValidatorRange{
+							{Start: 200, End: 208},
+						},
+						Source: "ethpandaops",
+					},
+				},
+				Validators: &ValidatorSummary{
+					TotalCount: 24, // (108-100) + (116-108) + (208-200) = 8 + 8 + 8 = 24
+				},
+				Groups: map[string][]string{
+					"lighthouse_geth":  {"lighthouse-geth-1", "lighthouse-geth-2"},
+					"prysm_nethermind": {"prysm-nethermind-1"},
+				},
+				Tags: map[string][]string{
+					"el:geth":       {"lighthouse-geth-1", "lighthouse-geth-2"},
+					"cl:lighthouse": {"lighthouse-geth-1", "lighthouse-geth-2"},
+					"el:nethermind": {"prysm-nethermind-1"},
+					"cl:prysm":      {"prysm-nethermind-1"},
+				},
+				Metadata: &Metadata{
+					Sources: []string{"https://example.com/inventory.ini"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "testinprod inventory with rangeOffset",
+			content: `[lighthouse_besu]
+lighthouse-besu-1 ansible_host=10.0.0.1 validator_start=0 validator_end=8 cloud=digitalocean cloud_region=nyc1
+lighthouse-besu-2 ansible_host=10.0.0.2 validator_start=8 validator_end=16 cloud=digitalocean cloud_region=sfo3
+
+[teku_geth]
+teku-geth-1 ansible_host=10.0.0.3 validator_start=100 validator_end=108 ethereum_node_cl_supernode_enabled=True
+`,
+			sourceURL:   "https://testinprod.com/inventory.ini",
+			sourceName:  "testinprod",
+			rangeOffset: 51312, // Apply offset to map local ranges to global
+			want: &ValidatorRanges{
+				Nodes: map[string]*Node{
+					"lighthouse-besu-1": {
+						Groups: []string{"lighthouse_besu"},
+						Tags:   []string{"el:besu", "cl:lighthouse"},
+						Attributes: map[string]interface{}{
+							"cloud":       "digitalocean",
+							"cloudRegion": "nyc1",
+						},
+						ValidatorRanges: []*ValidatorRange{
+							{Start: 51312, End: 51320}, // 0+51312 to 8+51312
+						},
+						Source: "testinprod",
+					},
+					"lighthouse-besu-2": {
+						Groups: []string{"lighthouse_besu"},
+						Tags:   []string{"el:besu", "cl:lighthouse"},
+						Attributes: map[string]interface{}{
+							"cloud":       "digitalocean",
+							"cloudRegion": "sfo3",
+						},
+						ValidatorRanges: []*ValidatorRange{
+							{Start: 51320, End: 51328}, // 8+51312 to 16+51312
+						},
+						Source: "testinprod",
+					},
+					"teku-geth-1": {
+						Groups: []string{"teku_geth"},
+						Tags:   []string{"el:geth", "cl:teku"},
+						Attributes: map[string]interface{}{
+							"isClSupernode": true,
+						},
+						ValidatorRanges: []*ValidatorRange{
+							{Start: 51412, End: 51420}, // 100+51312 to 108+51312
+						},
+						Source: "testinprod",
+					},
+				},
+				Validators: &ValidatorSummary{
+					TotalCount: 24, // 8 + 8 + 8 = 24
+				},
+				Groups: map[string][]string{
+					"lighthouse_besu": {"lighthouse-besu-1", "lighthouse-besu-2"},
+					"teku_geth":       {"teku-geth-1"},
+				},
+				Tags: map[string][]string{
+					"el:besu":       {"lighthouse-besu-1", "lighthouse-besu-2"},
+					"cl:lighthouse": {"lighthouse-besu-1", "lighthouse-besu-2"},
+					"el:geth":       {"teku-geth-1"},
+					"cl:teku":       {"teku-geth-1"},
+				},
+				Metadata: &Metadata{
+					Sources: []string{"https://testinprod.com/inventory.ini"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "nodes without validator ranges are filtered out",
+			content: `[bootnode]
+bootnode-1 ansible_host=192.168.1.1 cloud=aws
+
+[lighthouse_geth]
+lighthouse-geth-1 ansible_host=192.168.1.2 validator_start=100 validator_end=108
+lighthouse-geth-2 ansible_host=192.168.1.3
+
+[monitoring]
+grafana ansible_host=192.168.1.4
+prometheus ansible_host=192.168.1.5
+`,
+			sourceURL:   "https://example.com/inventory.ini",
+			sourceName:  "ethpandaops",
+			rangeOffset: 0,
+			want: &ValidatorRanges{
+				Nodes: map[string]*Node{
+					"lighthouse-geth-1": {
+						Groups:     []string{"lighthouse_geth"},
+						Tags:       []string{"el:geth", "cl:lighthouse"},
+						Attributes: map[string]interface{}{},
+						ValidatorRanges: []*ValidatorRange{
+							{Start: 100, End: 108},
+						},
+						Source: "ethpandaops",
+					},
+				},
+				Validators: &ValidatorSummary{
+					TotalCount: 8,
+				},
+				Groups: map[string][]string{
+					"lighthouse_geth": {"lighthouse-geth-1"},
+				},
+				Tags: map[string][]string{
+					"el:geth":       {"lighthouse-geth-1"},
+					"cl:lighthouse": {"lighthouse-geth-1"},
+				},
+				Metadata: &Metadata{
+					Sources: []string{"https://example.com/inventory.ini"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "boolean attribute parsing",
+			content: `[nimbus_reth]
+nimbus-reth-1 ansible_host=192.168.1.1 validator_start=0 validator_end=8 ethereum_node_cl_supernode_enabled=True
+nimbus-reth-2 ansible_host=192.168.1.2 validator_start=8 validator_end=16 ethereum_node_cl_supernode_enabled=false
+nimbus-reth-3 ansible_host=192.168.1.3 validator_start=16 validator_end=24 ethereum_node_cl_supernode_enabled=TRUE
+`,
+			sourceURL:   "https://example.com/inventory.ini",
+			sourceName:  "ethpandaops",
+			rangeOffset: 0,
+			want: &ValidatorRanges{
+				Nodes: map[string]*Node{
+					"nimbus-reth-1": {
+						Groups: []string{"nimbus_reth"},
+						Tags:   []string{"el:reth", "cl:nimbus"},
+						Attributes: map[string]interface{}{
+							"isClSupernode": true,
+						},
+						ValidatorRanges: []*ValidatorRange{
+							{Start: 0, End: 8},
+						},
+						Source: "ethpandaops",
+					},
+					"nimbus-reth-2": {
+						Groups: []string{"nimbus_reth"},
+						Tags:   []string{"el:reth", "cl:nimbus"},
+						Attributes: map[string]interface{}{
+							"isClSupernode": false,
+						},
+						ValidatorRanges: []*ValidatorRange{
+							{Start: 8, End: 16},
+						},
+						Source: "ethpandaops",
+					},
+					"nimbus-reth-3": {
+						Groups: []string{"nimbus_reth"},
+						Tags:   []string{"el:reth", "cl:nimbus"},
+						Attributes: map[string]interface{}{
+							"isClSupernode": true,
+						},
+						ValidatorRanges: []*ValidatorRange{
+							{Start: 16, End: 24},
+						},
+						Source: "ethpandaops",
+					},
+				},
+				Validators: &ValidatorSummary{
+					TotalCount: 24, // 8 + 8 + 8 = 24
+				},
+				Groups: map[string][]string{
+					"nimbus_reth": {"nimbus-reth-1", "nimbus-reth-2", "nimbus-reth-3"},
+				},
+				Tags: map[string][]string{
+					"el:reth":   {"nimbus-reth-1", "nimbus-reth-2", "nimbus-reth-3"},
+					"cl:nimbus": {"nimbus-reth-1", "nimbus-reth-2", "nimbus-reth-3"},
+				},
+				Metadata: &Metadata{
+					Sources: []string{"https://example.com/inventory.ini"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "camelCase attribute conversion",
+			content: `[lodestar_erigon]
+lodestar-erigon-1 ansible_host=192.168.1.1 validator_start=0 validator_end=8 cloud_region=us-east-1 some_long_attribute=value bandwidth=100
+`,
+			sourceURL:   "https://example.com/inventory.ini",
+			sourceName:  "ethpandaops",
+			rangeOffset: 0,
+			want: &ValidatorRanges{
+				Nodes: map[string]*Node{
+					"lodestar-erigon-1": {
+						Groups: []string{"lodestar_erigon"},
+						Tags:   []string{"el:erigon", "cl:lodestar"},
+						Attributes: map[string]interface{}{
+							"cloudRegion":       "us-east-1",
+							"someLongAttribute": "value",
+							"bandwidth":         "100",
+						},
+						ValidatorRanges: []*ValidatorRange{
+							{Start: 0, End: 8},
+						},
+						Source: "ethpandaops",
+					},
+				},
+				Validators: &ValidatorSummary{
+					TotalCount: 8,
+				},
+				Groups: map[string][]string{
+					"lodestar_erigon": {"lodestar-erigon-1"},
+				},
+				Tags: map[string][]string{
+					"el:erigon":   {"lodestar-erigon-1"},
+					"cl:lodestar": {"lodestar-erigon-1"},
+				},
+				Metadata: &Metadata{
+					Sources: []string{"https://example.com/inventory.ini"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "grandine client tag extraction",
+			content: `[grandine_besu]
+grandine-besu-1 ansible_host=192.168.1.1 validator_start=0 validator_end=8
+`,
+			sourceURL:   "https://example.com/inventory.ini",
+			sourceName:  "ethpandaops",
+			rangeOffset: 0,
+			want: &ValidatorRanges{
+				Nodes: map[string]*Node{
+					"grandine-besu-1": {
+						Groups:     []string{"grandine_besu"},
+						Tags:       []string{"el:besu", "cl:grandine"},
+						Attributes: map[string]interface{}{},
+						ValidatorRanges: []*ValidatorRange{
+							{Start: 0, End: 8},
+						},
+						Source: "ethpandaops",
+					},
+				},
+				Validators: &ValidatorSummary{
+					TotalCount: 8,
+				},
+				Groups: map[string][]string{
+					"grandine_besu": {"grandine-besu-1"},
+				},
+				Tags: map[string][]string{
+					"el:besu":     {"grandine-besu-1"},
+					"cl:grandine": {"grandine-besu-1"},
+				},
+				Metadata: &Metadata{
+					Sources: []string{"https://example.com/inventory.ini"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "validator client tag",
+			content: `[validator_lighthouse]
+validator-lighthouse-1 ansible_host=192.168.1.1 validator_start=0 validator_end=8
+`,
+			sourceURL:   "https://example.com/inventory.ini",
+			sourceName:  "ethpandaops",
+			rangeOffset: 0,
+			want: &ValidatorRanges{
+				Nodes: map[string]*Node{
+					"validator-lighthouse-1": {
+						Groups:     []string{"validator_lighthouse"},
+						Tags:       []string{"cl:lighthouse", "vc:validator"},
+						Attributes: map[string]interface{}{},
+						ValidatorRanges: []*ValidatorRange{
+							{Start: 0, End: 8},
+						},
+						Source: "ethpandaops",
+					},
+				},
+				Validators: &ValidatorSummary{
+					TotalCount: 8,
+				},
+				Groups: map[string][]string{
+					"validator_lighthouse": {"validator-lighthouse-1"},
+				},
+				Tags: map[string][]string{
+					"cl:lighthouse": {"validator-lighthouse-1"},
+					"vc:validator":  {"validator-lighthouse-1"},
+				},
+				Metadata: &Metadata{
+					Sources: []string{"https://example.com/inventory.ini"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:        "empty inventory",
+			content:     ``,
+			sourceURL:   "https://example.com/inventory.ini",
+			sourceName:  "ethpandaops",
+			rangeOffset: 0,
+			want: &ValidatorRanges{
+				Nodes:      map[string]*Node{},
+				Validators: &ValidatorSummary{TotalCount: 0},
+				Groups:     map[string][]string{},
+				Tags:       map[string][]string{},
+				Metadata: &Metadata{
+					Sources: []string{"https://example.com/inventory.ini"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "inventory with standalone hosts (should be filtered)",
+			content: `localhost
+
+[lighthouse_geth]
+lighthouse-geth-1 ansible_host=192.168.1.1 validator_start=0 validator_end=8
+
+some-random-host
+
+[teku_besu]
+teku-besu-1 ansible_host=192.168.1.2 validator_start=100 validator_end=108
+`,
+			sourceURL:   "https://example.com/inventory.ini",
+			sourceName:  "ethpandaops",
+			rangeOffset: 0,
+			want: &ValidatorRanges{
+				Nodes: map[string]*Node{
+					"lighthouse-geth-1": {
+						Groups:     []string{"lighthouse_geth"},
+						Tags:       []string{"el:geth", "cl:lighthouse"},
+						Attributes: map[string]interface{}{},
+						ValidatorRanges: []*ValidatorRange{
+							{Start: 0, End: 8},
+						},
+						Source: "ethpandaops",
+					},
+					"teku-besu-1": {
+						Groups:     []string{"teku_besu"},
+						Tags:       []string{"el:besu", "cl:teku"},
+						Attributes: map[string]interface{}{},
+						ValidatorRanges: []*ValidatorRange{
+							{Start: 100, End: 108},
+						},
+						Source: "ethpandaops",
+					},
+				},
+				Validators: &ValidatorSummary{
+					TotalCount: 16, // 8 + 8 = 16
+				},
+				Groups: map[string][]string{
+					"lighthouse_geth": {"lighthouse-geth-1"},
+					"teku_besu":       {"teku-besu-1"},
+				},
+				Tags: map[string][]string{
+					"el:geth":       {"lighthouse-geth-1"},
+					"cl:lighthouse": {"lighthouse-geth-1"},
+					"el:besu":       {"teku-besu-1"},
+					"cl:teku":       {"teku-besu-1"},
+				},
+				Metadata: &Metadata{
+					Sources: []string{"https://example.com/inventory.ini"},
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseInventory([]byte(tt.content), tt.sourceURL, tt.sourceName, tt.rangeOffset)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseInventory() error = %v, wantErr %v", err, tt.wantErr)
+
+				return
+			}
+			if !tt.wantErr {
+				// Check individual fields instead of using DeepEqual on the whole struct
+				// because map iteration order is not guaranteed
+
+				// Check nodes
+				if !reflect.DeepEqual(got.Nodes, tt.want.Nodes) {
+					t.Errorf("Nodes mismatch")
+					for name, node := range got.Nodes {
+						if wantNode, exists := tt.want.Nodes[name]; exists {
+							if !reflect.DeepEqual(node, wantNode) {
+								t.Errorf("Node %s:\ngot  %+v\nwant %+v", name, node, wantNode)
+							}
+						} else {
+							t.Errorf("Unexpected node: %s", name)
+						}
+					}
+					for name := range tt.want.Nodes {
+						if _, exists := got.Nodes[name]; !exists {
+							t.Errorf("Missing node: %s", name)
+						}
+					}
+				}
+
+				// Check validators
+				if got.Validators.TotalCount != tt.want.Validators.TotalCount {
+					t.Errorf("TotalCount = %v, want %v", got.Validators.TotalCount, tt.want.Validators.TotalCount)
+				} else {
+					t.Logf("TotalCount matches: %v", got.Validators.TotalCount)
+				}
+
+				// Check groups - compare each group's nodes without caring about order
+				if len(got.Groups) != len(tt.want.Groups) {
+					t.Errorf("Groups count mismatch: got %d, want %d", len(got.Groups), len(tt.want.Groups))
+				}
+				for group, nodes := range tt.want.Groups {
+					if gotNodes, exists := got.Groups[group]; exists {
+						if !slicesContainSameElements(gotNodes, nodes) {
+							t.Errorf("Group %s nodes mismatch:\ngot  %+v\nwant %+v", group, gotNodes, nodes)
+						}
+					} else {
+						t.Errorf("Missing group: %s", group)
+					}
+				}
+
+				// Check tags - compare each tag's nodes without caring about order
+				if len(got.Tags) != len(tt.want.Tags) {
+					t.Errorf("Tags count mismatch: got %d, want %d", len(got.Tags), len(tt.want.Tags))
+				}
+				for tag, nodes := range tt.want.Tags {
+					if gotNodes, exists := got.Tags[tag]; exists {
+						if !slicesContainSameElements(gotNodes, nodes) {
+							t.Errorf("Tag %s nodes mismatch:\ngot  %+v\nwant %+v", tag, gotNodes, nodes)
+						}
+					} else {
+						t.Errorf("Missing tag: %s", tag)
+					}
+				}
+
+				// Check metadata
+				if !reflect.DeepEqual(got.Metadata, tt.want.Metadata) {
+					t.Errorf("Metadata mismatch:\ngot  %+v\nwant %+v", got.Metadata, tt.want.Metadata)
+				}
+			}
+		})
+	}
+}

--- a/pkg/validatorranges/service.go
+++ b/pkg/validatorranges/service.go
@@ -1,0 +1,237 @@
+package validatorranges
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/ethpandaops/cartographoor/pkg/discovery"
+	"github.com/ethpandaops/cartographoor/pkg/storage/s3"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sync/semaphore"
+)
+
+// Service handles the generation and upload of validator ranges.
+type Service struct {
+	fetcher   *Fetcher
+	s3Storage *s3.Provider
+	config    *Config
+	logger    *logrus.Entry
+}
+
+// NewService creates a new validator ranges service.
+func NewService(s3Storage *s3.Provider, config *Config, logger *logrus.Logger) *Service {
+	return &Service{
+		fetcher:   NewFetcher(),
+		s3Storage: s3Storage,
+		config:    config,
+		logger:    logger.WithField("module", "validator_ranges"),
+	}
+}
+
+// GenerateValidatorRanges processes all networks to generate validator range data.
+func (s *Service) GenerateValidatorRanges(ctx context.Context, networks map[string]discovery.Network) error {
+	s.logger.WithField("networks", len(networks)).Info("Generating validator ranges for networks")
+
+	// Use semaphore to limit concurrency to 5 networks at a time
+	sem := semaphore.NewWeighted(5)
+
+	for name, network := range networks {
+		if err := sem.Acquire(ctx, 1); err != nil {
+			return fmt.Errorf("failed to acquire semaphore: %w", err)
+		}
+
+		go func(networkName string, net discovery.Network) {
+			defer sem.Release(1)
+
+			if err := s.processNetwork(ctx, networkName, net); err != nil {
+				s.logger.WithFields(logrus.Fields{
+					"network": networkName,
+					"error":   err,
+				}).Error("Failed to process network")
+			}
+		}(name, network)
+	}
+
+	// Wait for all networks to be processed
+	if err := sem.Acquire(ctx, 5); err != nil {
+		return fmt.Errorf("failed to wait for completion: %w", err)
+	}
+
+	sem.Release(5)
+
+	s.logger.Info("Validator ranges generation completed")
+
+	return nil
+}
+
+// processNetwork handles the processing of a single network.
+func (s *Service) processNetwork(ctx context.Context, networkName string, network discovery.Network) error {
+	s.logger.WithField("network", networkName).Debug("Processing network")
+
+	// Fetch from ethpandaops repository
+	ethpandaopsRanges, err := s.fetchEthpandaopsRanges(ctx, networkName, network)
+	if err != nil {
+		s.logger.WithFields(logrus.Fields{
+			"network": networkName,
+			"error":   err,
+		}).Warn("Failed to fetch ethpandaops ranges")
+		// Continue even if ethpandaops fetch fails
+	}
+
+	// Fetch from additional sources if configured
+	additionalRanges, err := s.fetchAdditionalRanges(ctx, networkName)
+	if err != nil {
+		s.logger.WithFields(logrus.Fields{
+			"network": networkName,
+			"error":   err,
+		}).Warn("Failed to fetch additional ranges")
+		// Continue even if additional fetches fail
+	}
+
+	// Combine all ranges
+	allRanges := []*ValidatorRanges{}
+	if ethpandaopsRanges != nil {
+		allRanges = append(allRanges, ethpandaopsRanges)
+	}
+
+	allRanges = append(allRanges, additionalRanges...)
+
+	if len(allRanges) == 0 {
+		s.logger.WithField("network", networkName).Info("No validator ranges found, skipping")
+
+		return nil
+	}
+
+	// Aggregate all ranges
+	aggregatedRanges := AggregateRanges(allRanges)
+	aggregatedRanges.Metadata.NetworkName = networkName
+
+	// Upload to S3
+	if err := s.uploadToS3(ctx, networkName, aggregatedRanges); err != nil {
+		return fmt.Errorf("failed to upload to S3: %w", err)
+	}
+
+	s.logger.WithFields(logrus.Fields{
+		"network":    networkName,
+		"validators": aggregatedRanges.Validators.TotalCount,
+		"nodes":      len(aggregatedRanges.Nodes),
+	}).Info("Successfully processed network")
+
+	return nil
+}
+
+// fetchEthpandaopsRanges fetches validator ranges from the ethpandaops repository.
+func (s *Service) fetchEthpandaopsRanges(ctx context.Context, networkName string, network discovery.Network) (*ValidatorRanges, error) {
+	// Extract repository from network
+	repo := network.Repository
+	if repo == "" {
+		repo = "ethpandaops/ansible"
+	}
+
+	// Strip repository-specific prefixes from network name for inventory path
+	inventoryName := networkName
+	// Common prefixes to strip (e.g., "fusaka-devnet-5" -> "devnet-5")
+	prefixes := []string{"fusaka-", "pectra-", "dencun-", "eof-", "verkle-"}
+	for _, prefix := range prefixes {
+		if strings.HasPrefix(networkName, prefix) {
+			inventoryName = strings.TrimPrefix(networkName, prefix)
+
+			break
+		}
+	}
+
+	// Build inventory URLs
+	urls := s.fetcher.BuildInventoryURLs(repo, inventoryName)
+
+	// Fetch inventory files
+	contents, successfulURLs, err := s.fetcher.FetchMultiple(ctx, urls)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch inventory files: %w", err)
+	}
+
+	// Parse and aggregate all inventory files
+	allRanges := make([]*ValidatorRanges, 0, len(contents))
+
+	for i, content := range contents {
+		ranges, err := ParseInventory(content, successfulURLs[i], "ethpandaops", 0)
+		if err != nil {
+			s.logger.WithFields(logrus.Fields{
+				"url":   successfulURLs[i],
+				"error": err,
+			}).Warn("Failed to parse inventory")
+
+			continue
+		}
+
+		allRanges = append(allRanges, ranges)
+	}
+
+	if len(allRanges) == 0 {
+		return nil, fmt.Errorf("no valid inventory files found")
+	}
+
+	// Aggregate all ranges from ethpandaops
+	return AggregateRanges(allRanges), nil
+}
+
+// fetchAdditionalRanges fetches validator ranges from additional configured sources.
+func (s *Service) fetchAdditionalRanges(ctx context.Context, networkName string) ([]*ValidatorRanges, error) {
+	if s.config == nil || s.config.AdditionalSources == nil {
+		return nil, nil
+	}
+
+	sources, exists := s.config.AdditionalSources[networkName]
+	if !exists || len(sources) == 0 {
+		return nil, nil
+	}
+
+	allRanges := make([]*ValidatorRanges, 0, len(sources))
+
+	for _, source := range sources {
+		content, err := s.fetcher.FetchInventoryFile(ctx, source.URL)
+		if err != nil {
+			s.logger.WithFields(logrus.Fields{
+				"url":   source.URL,
+				"name":  source.Name,
+				"error": err,
+			}).Warn("Failed to fetch additional source")
+
+			continue
+		}
+
+		ranges, err := ParseInventory(content, source.URL, source.Name, source.RangeOffset)
+		if err != nil {
+			s.logger.WithFields(logrus.Fields{
+				"url":   source.URL,
+				"name":  source.Name,
+				"error": err,
+			}).Warn("Failed to parse additional source")
+
+			continue
+		}
+
+		allRanges = append(allRanges, ranges)
+	}
+
+	return allRanges, nil
+}
+
+// uploadToS3 uploads validator ranges data to S3.
+func (s *Service) uploadToS3(ctx context.Context, networkName string, data *ValidatorRanges) error {
+	// Marshal data to JSON
+	jsonData, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal validator ranges: %w", err)
+	}
+
+	// Upload to S3
+	key := fmt.Sprintf("validator-ranges/%s.json", networkName)
+
+	if err := s.s3Storage.UploadRaw(ctx, key, jsonData, "application/json"); err != nil {
+		return fmt.Errorf("failed to upload to S3: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/validatorranges/types.go
+++ b/pkg/validatorranges/types.go
@@ -1,0 +1,48 @@
+package validatorranges
+
+// ValidatorRanges represents the complete validator range data for a network.
+type ValidatorRanges struct {
+	Nodes      map[string]*Node    `json:"nodes"`
+	Validators *ValidatorSummary   `json:"validators"`
+	Groups     map[string][]string `json:"groups"`
+	Tags       map[string][]string `json:"tags"`
+	Metadata   *Metadata           `json:"metadata"`
+}
+
+// Node represents a single node with its validator range assignments.
+type Node struct {
+	Groups          []string               `json:"groups"`
+	Tags            []string               `json:"tags"`
+	Attributes      map[string]interface{} `json:"attributes"`
+	ValidatorRanges []*ValidatorRange      `json:"validatorRanges"`
+	Source          string                 `json:"source"`
+}
+
+// ValidatorRange represents a range of validators assigned to a node.
+type ValidatorRange struct {
+	Start int `json:"start"`
+	End   int `json:"end"`
+}
+
+// ValidatorSummary provides summary statistics about validators.
+type ValidatorSummary struct {
+	TotalCount int `json:"totalCount"`
+}
+
+// Metadata contains information about the validator ranges data.
+type Metadata struct {
+	NetworkName string   `json:"networkName"`
+	Sources     []string `json:"sources"`
+}
+
+// Config represents the configuration for validator ranges.
+type Config struct {
+	AdditionalSources map[string][]SourceConfig `json:"additionalSources" mapstructure:"additionalSources"`
+}
+
+// SourceConfig represents configuration for a single validator data source.
+type SourceConfig struct {
+	URL         string `json:"url" mapstructure:"url"`
+	Name        string `json:"name" mapstructure:"name"`
+	RangeOffset int    `json:"rangeOffset" mapstructure:"rangeOffset"`
+}


### PR DESCRIPTION
This PR implements a new validator-ranges command that parses Ansible inventory files to extract and aggregate validator range assignments across Ethereum testnets. This feature enables tracking which nodes are responsible for which validators, supporting both ethpandaops and third-party validator sources.

**Example cfg:**

```yaml
  validatorRanges:
    additionalSources:
      fusaka-devnet-5:
        - url: https://raw.githubusercontent.com/testinprod-io/fusaka-devnets/.../inventory.ini
          name: testinprod
          rangeOffset: 51312  # Maps testinprod's local 0-4688 to global 51312-56000
```

**To run:**

```bash
./cartographoor validator-ranges --config config.yaml
```

[fusaka-devnet-5-example.json](https://github.com/user-attachments/files/22372984/fusaka-devnet-5-example.json)
