### PR TITLE
feat(inventory): add DNS and HTTPS validation for dora client URLs

### DIFF
--- a/cmd/cartographoor/cmd/inventory.go
+++ b/cmd/cartographoor/cmd/inventory.go
@@ -6,13 +6,13 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
-
-	"github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+	"time"
 
 	"github.com/ethpandaops/cartographoor/pkg/inventory"
 	"github.com/ethpandaops/cartographoor/pkg/storage/s3"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 type inventoryConfig struct {
@@ -20,7 +20,18 @@ type inventoryConfig struct {
 		Level string `mapstructure:"level"`
 	} `mapstructure:"logging"`
 	ConfigFile string
-	Storage    s3.Config `mapstructure:"storage"`
+	Storage    s3.Config         `mapstructure:"storage"`
+	Inventory  inventorySettings `mapstructure:"inventory"`
+}
+
+type inventorySettings struct {
+	Validation validationSettings `mapstructure:"validation"`
+}
+
+type validationSettings struct {
+	Enabled                  *bool  `mapstructure:"enabled"`
+	DNSTimeout               string `mapstructure:"dnsTimeout"`
+	MaxConcurrentValidations int64  `mapstructure:"maxConcurrentValidations"`
 }
 
 func newInventoryCmd(log *logrus.Logger) *cobra.Command {
@@ -86,8 +97,18 @@ func runInventory(ctx context.Context, log *logrus.Logger, cfg *inventoryConfig)
 		cancel()
 	}()
 
+	// Parse and prepare inventory configuration
+	inventoryCfg, err := prepareInventoryConfig(&cfg.Inventory)
+	if err != nil {
+		return fmt.Errorf("failed to prepare inventory configuration: %w", err)
+	}
+
 	// Create inventory service
-	service, err := inventory.NewService(log.WithField("component", "inventory"), cfg.Storage)
+	service, err := inventory.NewService(
+		log.WithField("component", "inventory"),
+		cfg.Storage,
+		*inventoryCfg,
+	)
 	if err != nil {
 		return fmt.Errorf("failed to create inventory service: %w", err)
 	}
@@ -102,4 +123,41 @@ func runInventory(ctx context.Context, log *logrus.Logger, cfg *inventoryConfig)
 	log.Info("Inventory generation completed successfully")
 
 	return nil
+}
+
+// prepareInventoryConfig prepares the inventory configuration with defaults.
+func prepareInventoryConfig(cfg *inventorySettings) (*inventory.Config, error) {
+	// Default values
+	const (
+		defaultEnabled                  = true
+		defaultMaxConcurrentValidations = int64(100)
+	)
+
+	inventoryCfg := &inventory.Config{
+		Validation: inventory.ValidationConfig{
+			Enabled:                  defaultEnabled,
+			DNSTimeout:               3 * time.Second,
+			MaxConcurrentValidations: defaultMaxConcurrentValidations,
+		},
+	}
+
+	// Override with configured values if provided
+	if cfg.Validation.Enabled != nil {
+		inventoryCfg.Validation.Enabled = *cfg.Validation.Enabled
+	}
+
+	if cfg.Validation.DNSTimeout != "" {
+		timeout, err := time.ParseDuration(cfg.Validation.DNSTimeout)
+		if err != nil {
+			return nil, fmt.Errorf("invalid dnsTimeout value: %w", err)
+		}
+
+		inventoryCfg.Validation.DNSTimeout = timeout
+	}
+
+	if cfg.Validation.MaxConcurrentValidations > 0 {
+		inventoryCfg.Validation.MaxConcurrentValidations = cfg.Validation.MaxConcurrentValidations
+	}
+
+	return inventoryCfg, nil
 }

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -66,10 +66,24 @@ storage:
   maxRetries: 3
   backoffJitterPercent: 20
 
+# Inventory generation configuration
+inventory:
+  validation:
+    # Enable/disable DNS validation of constructed URLs
+    # When enabled, clients with unresolvable hostnames are excluded from inventory
+    # When disabled, all clients are included regardless of DNS validity
+    enabled: true
+
+    # DNS validation timeout per hostname
+    dnsTimeout: 3s
+
+    # Maximum concurrent DNS validations
+    maxConcurrentValidations: 100
+
 # Validator ranges configuration (optional)
 validatorRanges:
   # Additional third-party validator sources
-  # 
+  #
   # Validator Range Distribution:
   # On testnets, validators are typically distributed across multiple organizations.
   # Each organization may number their validators locally starting from 0, but globally

--- a/pkg/inventory/config.go
+++ b/pkg/inventory/config.go
@@ -1,0 +1,20 @@
+package inventory
+
+import "time"
+
+// Config holds configuration for inventory generation.
+type Config struct {
+	Validation ValidationConfig
+}
+
+// ValidationConfig holds configuration for URL validation.
+type ValidationConfig struct {
+	// Enabled controls whether DNS validation is performed
+	Enabled bool
+
+	// DNSTimeout is the timeout for each DNS hostname lookup
+	DNSTimeout time.Duration
+
+	// MaxConcurrentValidations is the maximum number of concurrent DNS validations
+	MaxConcurrentValidations int64
+}

--- a/pkg/inventory/validator.go
+++ b/pkg/inventory/validator.go
@@ -1,0 +1,225 @@
+package inventory
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sync/semaphore"
+)
+
+// Validator validates client URLs using DNS resolution and HTTP checks.
+type Validator struct {
+	log         *logrus.Entry
+	dnsTimeout  time.Duration
+	httpTimeout time.Duration
+	httpClient  *http.Client
+	sem         *semaphore.Weighted
+}
+
+// NewValidator creates a new Validator instance.
+//
+// Parameters:
+//   - log: logger with component field already set
+//   - dnsTimeout: timeout for each DNS lookup (e.g., 3*time.Second)
+//   - maxConcurrent: max concurrent validation operations (DNS + HTTPS HEAD requests)
+func NewValidator(
+	log *logrus.Entry,
+	dnsTimeout time.Duration,
+	maxConcurrent int64,
+) *Validator {
+	httpTimeout := dnsTimeout * 2 // HTTP timeout is 2x DNS timeout (e.g., 6s)
+
+	return &Validator{
+		log:         log.WithField("component", "inventory_validator"),
+		dnsTimeout:  dnsTimeout,
+		httpTimeout: httpTimeout,
+		httpClient: &http.Client{
+			Timeout: httpTimeout,
+			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				return http.ErrUseLastResponse // Don't follow redirects
+			},
+		},
+		sem: semaphore.NewWeighted(maxConcurrent),
+	}
+}
+
+// ValidateClient validates all URLs for a client.
+// If ANY URL validation fails, the entire client is considered invalid.
+// SSH URLs are validated via DNS only.
+// BeaconAPI and RPC URLs are validated via HTTPS HEAD request.
+//
+// Parameters:
+//   - ctx: context for cancellation and timeout
+//   - client: the client with URLs to validate
+//
+// Returns:
+//   - error: non-nil if any URL validation fails
+func (v *Validator) ValidateClient(
+	ctx context.Context,
+	client ClientInfo,
+) error {
+	// Validate SSH URL (DNS only - can't HTTP check SSH protocol)
+	if client.SSH != "" {
+		if err := v.validateHostname(ctx, "ssh", client.SSH); err != nil {
+			return fmt.Errorf("SSH URL validation failed: %w", err)
+		}
+	}
+
+	// Validate BeaconAPI URL (HTTPS HEAD request)
+	if client.BeaconAPI != "" {
+		if err := v.validateHTTPEndpoint(ctx, "beacon-api", client.BeaconAPI); err != nil {
+			return fmt.Errorf("BeaconAPI URL validation failed: %w", err)
+		}
+	}
+
+	// Validate RPC URL (HTTPS HEAD request)
+	if client.RPC != "" {
+		if err := v.validateHTTPEndpoint(ctx, "rpc", client.RPC); err != nil {
+			return fmt.Errorf("RPC URL validation failed: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// validateHostname performs DNS lookup for a hostname.
+//
+// Parameters:
+//   - ctx: context for cancellation
+//   - urlType: "ssh", "beacon-api", or "rpc" for logging
+//   - url: the full URL string
+func (v *Validator) validateHostname(
+	ctx context.Context,
+	urlType,
+	url string,
+) error {
+	hostname := v.extractHostname(url)
+
+	// Acquire semaphore to limit concurrent DNS lookups
+	if err := v.sem.Acquire(ctx, 1); err != nil {
+		return fmt.Errorf("failed to acquire semaphore: %w", err)
+	}
+	defer v.sem.Release(1)
+
+	// Create context with timeout for DNS lookup
+	lookupCtx, cancel := context.WithTimeout(ctx, v.dnsTimeout)
+	defer cancel()
+
+	// Perform DNS lookup
+	addrs, err := net.DefaultResolver.LookupHost(lookupCtx, hostname)
+	if err != nil {
+		v.log.WithFields(logrus.Fields{
+			"url_type": urlType,
+			"url":      url,
+			"hostname": hostname,
+			"error":    err,
+		}).Warn("DNS validation failed")
+
+		return fmt.Errorf(
+			"DNS lookup failed for %s URL %s (hostname: %s): %w",
+			urlType,
+			url,
+			hostname,
+			err,
+		)
+	}
+
+	// Verify we got at least one address
+	if len(addrs) == 0 {
+		v.log.WithFields(logrus.Fields{
+			"url_type": urlType,
+			"url":      url,
+			"hostname": hostname,
+		}).Warn("DNS validation returned no addresses")
+
+		return fmt.Errorf(
+			"DNS lookup returned no addresses for %s URL %s (hostname: %s)",
+			urlType,
+			url,
+			hostname,
+		)
+	}
+
+	return nil
+}
+
+// validateHTTPEndpoint validates an HTTPS endpoint via HTTP HEAD request.
+// Only HTTPS is attempted - HTTP fallback is not used.
+// DNS resolution is performed implicitly by the HTTP client.
+func (v *Validator) validateHTTPEndpoint(ctx context.Context, urlType, hostname string) error {
+	// Acquire semaphore for HTTP request
+	if err := v.sem.Acquire(ctx, 1); err != nil {
+		return fmt.Errorf("failed to acquire semaphore for %s URL validation: %w", urlType, err)
+	}
+	defer v.sem.Release(1)
+
+	// Only try HTTPS - do not fall back to HTTP
+	httpsURL := "https://" + hostname
+	if err := v.doHTTPHead(ctx, httpsURL); err != nil {
+		v.log.WithFields(logrus.Fields{
+			"url_type": urlType,
+			"hostname": hostname,
+			"error":    err,
+		}).Warn("Client URL validation failed")
+
+		return fmt.Errorf("failed to validate %s URL %s via HTTPS: %w", urlType, hostname, err)
+	}
+
+	return nil
+}
+
+// doHTTPHead performs an HTTP HEAD request to check if an endpoint is accessible.
+func (v *Validator) doHTTPHead(ctx context.Context, url string) error {
+	reqCtx, cancel := context.WithTimeout(ctx, v.httpTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodHead, url, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create HTTP HEAD request: %w", err)
+	}
+
+	resp, err := v.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("HTTP HEAD request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Accept 2xx (success), 3xx (redirects), or 401/404/405 (service exists but requires auth/endpoint missing/method not allowed)
+	// Since we only use HTTPS, redirects are acceptable
+	if resp.StatusCode >= 200 && resp.StatusCode < 400 {
+		return nil
+	}
+
+	// 401/404/405 means service is running but requires auth, endpoint doesn't exist, or method not allowed
+	// This is acceptable - the service is accessible
+	if resp.StatusCode == http.StatusUnauthorized ||
+		resp.StatusCode == http.StatusNotFound ||
+		resp.StatusCode == http.StatusMethodNotAllowed {
+		return nil
+	}
+
+	return fmt.Errorf("unexpected HTTP status code: %d", resp.StatusCode)
+}
+
+// extractHostname extracts hostname from URL.
+//
+// Handles different URL formats:
+//   - SSH URL: "devops@hostname" → "hostname"
+//   - BeaconAPI/RPC: "hostname" → "hostname" (no change)
+func (v *Validator) extractHostname(url string) string {
+	// Handle SSH URLs with user@host format
+	if strings.Contains(url, "@") {
+		parts := strings.Split(url, "@")
+		if len(parts) == 2 {
+			return parts[1]
+		}
+	}
+
+	// For BeaconAPI/RPC URLs, return as-is
+	return url
+}

--- a/pkg/inventory/validator_test.go
+++ b/pkg/inventory/validator_test.go
@@ -1,0 +1,360 @@
+package inventory
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestExtractHostname tests hostname extraction from various URL formats.
+func TestExtractHostname(t *testing.T) {
+	tests := []struct {
+		name     string
+		url      string
+		expected string
+	}{
+		{
+			name:     "SSH URL with user",
+			url:      "devops@lighthouse-geth-1.fusaka.ethpandaops.io",
+			expected: "lighthouse-geth-1.fusaka.ethpandaops.io",
+		},
+		{
+			name:     "BeaconAPI URL",
+			url:      "bn-lighthouse-geth-1.fusaka.ethpandaops.io",
+			expected: "bn-lighthouse-geth-1.fusaka.ethpandaops.io",
+		},
+		{
+			name:     "RPC URL",
+			url:      "rpc-lighthouse-geth-1.fusaka.ethpandaops.io",
+			expected: "rpc-lighthouse-geth-1.fusaka.ethpandaops.io",
+		},
+		{
+			name:     "Simple hostname",
+			url:      "google.com",
+			expected: "google.com",
+		},
+		{
+			name:     "SSH URL with different user",
+			url:      "admin@server.example.com",
+			expected: "server.example.com",
+		},
+		{
+			name:     "URL with subdomain",
+			url:      "api.service.example.com",
+			expected: "api.service.example.com",
+		},
+	}
+
+	log := logrus.New().WithField("test", "extract_hostname")
+	validator := NewValidator(log, 3*time.Second, 10)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := validator.extractHostname(tt.url)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// TestValidateClient_ValidHostnames tests successful validation with real resolvable hostnames.
+func TestValidateClient_ValidHostnames(t *testing.T) {
+	log := logrus.New().WithField("test", "valid_hostnames")
+	validator := NewValidator(log, 5*time.Second, 15)
+	ctx := context.Background()
+
+	tests := []struct {
+		name   string
+		client ClientInfo
+	}{
+		{
+			name: "Consensus client with valid hostnames",
+			client: ClientInfo{
+				ClientName: "test-lighthouse-1",
+				ClientType: "lighthouse",
+				SSH:        "devops@google.com",
+				BeaconAPI:  "cloudflare.com",
+			},
+		},
+		{
+			name: "Execution client with valid hostnames",
+			client: ClientInfo{
+				ClientName: "test-geth-1",
+				ClientType: "geth",
+				SSH:        "devops@github.com",
+				RPC:        "amazon.com",
+			},
+		},
+		{
+			name: "Client with only SSH",
+			client: ClientInfo{
+				ClientName: "test-client",
+				ClientType: "test",
+				SSH:        "devops@dns.google",
+			},
+		},
+		{
+			name: "Consensus client with all URLs",
+			client: ClientInfo{
+				ClientName: "test-prysm-1",
+				ClientType: "prysm",
+				SSH:        "devops@microsoft.com",
+				BeaconAPI:  "apple.com",
+			},
+		},
+		{
+			name: "Execution client with all URLs",
+			client: ClientInfo{
+				ClientName: "test-nethermind-1",
+				ClientType: "nethermind",
+				SSH:        "devops@dns.google",
+				RPC:        "example.com",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validator.ValidateClient(ctx, tt.client)
+			assert.NoError(t, err, "Expected validation to succeed for all valid URLs")
+		})
+	}
+}
+
+// TestValidateClient_InvalidHostnames tests that clients with any invalid URL fail validation.
+func TestValidateClient_InvalidHostnames(t *testing.T) {
+	log := logrus.New().WithField("test", "invalid_hostnames")
+	validator := NewValidator(log, 3*time.Second, 15)
+	ctx := context.Background()
+
+	tests := []struct {
+		name   string
+		client ClientInfo
+	}{
+		{
+			name: "Consensus client with invalid SSH hostname",
+			client: ClientInfo{
+				ClientName: "test-lighthouse-1",
+				ClientType: "lighthouse",
+				SSH:        "devops@invalid-hostname-that-does-not-exist-12345.com",
+				BeaconAPI:  "cloudflare.com",
+			},
+		},
+		{
+			name: "Consensus client with invalid BeaconAPI hostname",
+			client: ClientInfo{
+				ClientName: "test-lighthouse-2",
+				ClientType: "lighthouse",
+				SSH:        "devops@google.com",
+				BeaconAPI:  "invalid-beacon-api-hostname-xyz-999.com",
+			},
+		},
+		{
+			name: "Execution client with invalid SSH hostname",
+			client: ClientInfo{
+				ClientName: "test-geth-1",
+				ClientType: "geth",
+				SSH:        "devops@this-domain-definitely-does-not-exist-abc123.com",
+				RPC:        "cloudflare.com",
+			},
+		},
+		{
+			name: "Execution client with invalid RPC hostname",
+			client: ClientInfo{
+				ClientName: "test-geth-2",
+				ClientType: "geth",
+				SSH:        "devops@google.com",
+				RPC:        "invalid-rpc-endpoint-hostname-test-456.com",
+			},
+		},
+		{
+			name: "Client with all invalid hostnames",
+			client: ClientInfo{
+				ClientName: "test-bad-client",
+				ClientType: "test",
+				SSH:        "devops@bad-ssh-host-xyz-111.com",
+				BeaconAPI:  "bad-beacon-host-xyz-222.com",
+				RPC:        "bad-rpc-host-xyz-333.com",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validator.ValidateClient(ctx, tt.client)
+			require.Error(t, err, "Expected validation to fail for client with invalid URL(s)")
+		})
+	}
+}
+
+// TestValidateClient_EmptyURLs tests that empty URLs are skipped during validation.
+func TestValidateClient_EmptyURLs(t *testing.T) {
+	log := logrus.New().WithField("test", "empty_urls")
+	validator := NewValidator(log, 3*time.Second, 15)
+	ctx := context.Background()
+
+	tests := []struct {
+		name   string
+		client ClientInfo
+	}{
+		{
+			name: "Client with empty SSH",
+			client: ClientInfo{
+				ClientName: "test-client-1",
+				ClientType: "lighthouse",
+				SSH:        "",
+				BeaconAPI:  "cloudflare.com",
+			},
+		},
+		{
+			name: "Client with empty BeaconAPI",
+			client: ClientInfo{
+				ClientName: "test-client-2",
+				ClientType: "lighthouse",
+				SSH:        "devops@google.com",
+				BeaconAPI:  "",
+			},
+		},
+		{
+			name: "Client with empty RPC",
+			client: ClientInfo{
+				ClientName: "test-client-3",
+				ClientType: "geth",
+				SSH:        "devops@google.com",
+				RPC:        "",
+			},
+		},
+		{
+			name: "Client with all empty URLs",
+			client: ClientInfo{
+				ClientName: "test-client-4",
+				ClientType: "test",
+				SSH:        "",
+				BeaconAPI:  "",
+				RPC:        "",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validator.ValidateClient(ctx, tt.client)
+			assert.NoError(t, err, "Empty URLs should not cause validation to fail")
+		})
+	}
+}
+
+// TestNewValidator tests validator constructor with various parameters.
+func TestNewValidator(t *testing.T) {
+	log := logrus.New().WithField("test", "new_validator")
+
+	tests := []struct {
+		name          string
+		dnsTimeout    time.Duration
+		maxConcurrent int64
+		expectNotNil  bool
+	}{
+		{
+			name:          "Standard configuration",
+			dnsTimeout:    3 * time.Second,
+			maxConcurrent: 15,
+			expectNotNil:  true,
+		},
+		{
+			name:          "Low concurrency",
+			dnsTimeout:    5 * time.Second,
+			maxConcurrent: 1,
+			expectNotNil:  true,
+		},
+		{
+			name:          "High concurrency",
+			dnsTimeout:    1 * time.Second,
+			maxConcurrent: 100,
+			expectNotNil:  true,
+		},
+		{
+			name:          "Very short timeout",
+			dnsTimeout:    100 * time.Millisecond,
+			maxConcurrent: 10,
+			expectNotNil:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			validator := NewValidator(log, tt.dnsTimeout, tt.maxConcurrent)
+			if tt.expectNotNil {
+				assert.NotNil(t, validator, "Validator should not be nil")
+				assert.NotNil(t, validator.log, "Logger should not be nil")
+				assert.NotNil(t, validator.sem, "Semaphore should not be nil")
+				assert.Equal(t, tt.dnsTimeout, validator.dnsTimeout, "DNS timeout should match")
+			}
+		})
+	}
+}
+
+// TestValidateHostname_DirectCall tests the validateHostname method directly.
+func TestValidateHostname_DirectCall(t *testing.T) {
+	log := logrus.New().WithField("test", "validate_hostname_direct")
+	validator := NewValidator(log, 3*time.Second, 15)
+	ctx := context.Background()
+
+	tests := []struct {
+		name        string
+		urlType     string
+		url         string
+		shouldError bool
+	}{
+		{
+			name:        "Valid SSH URL",
+			urlType:     "ssh",
+			url:         "devops@google.com",
+			shouldError: false,
+		},
+		{
+			name:        "Valid BeaconAPI URL",
+			urlType:     "beacon-api",
+			url:         "cloudflare.com",
+			shouldError: false,
+		},
+		{
+			name:        "Valid RPC URL",
+			urlType:     "rpc",
+			url:         "github.com",
+			shouldError: false,
+		},
+		{
+			name:        "Invalid SSH URL",
+			urlType:     "ssh",
+			url:         "devops@this-host-does-not-exist-xyz-123.com",
+			shouldError: true,
+		},
+		{
+			name:        "Invalid BeaconAPI URL",
+			urlType:     "beacon-api",
+			url:         "invalid-beacon-host-xyz-456.com",
+			shouldError: true,
+		},
+		{
+			name:        "Invalid RPC URL",
+			urlType:     "rpc",
+			url:         "invalid-rpc-host-xyz-789.com",
+			shouldError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validator.validateHostname(ctx, tt.urlType, tt.url)
+			if tt.shouldError {
+				require.Error(t, err, "Expected validation to fail")
+				assert.Contains(t, err.Error(), tt.urlType, "Error should contain URL type")
+			} else {
+				assert.NoError(t, err, "Expected validation to succeed")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Introduce a new Validator component that performs DNS resolution and HTTPS HEAD checks on every client URL before including it in the inventory. This prevents broken or unreachable endpoints from being published.

Validation is controlled by new inventory.validation configuration settings:
- enabled – toggle validation on/off
- dnsTimeout – per-host lookup timeout
- maxConcurrentValidations – limit concurrent checks

The Generator now filters out any client whose SSH, BeaconAPI or RPC URL fails validation. Empty URLs are skipped. Validation can be disabled entirely if need be.
