### PR TITLE
feat(networks): adds genesis_delay field to network discovery output alongside existing genesis_time

### DIFF
--- a/.github/config.production.yaml
+++ b/.github/config.production.yaml
@@ -18,7 +18,8 @@ discovery:
       - name: mainnet
         description: Production Ethereum network
         chainId: 1
-        genesisTime: 1606824023
+        genesisTime: 1606824000
+        genesisDelay: 604800
         configUrl: "https://raw.githubusercontent.com/eth-clients/mainnet/refs/heads/main/metadata/config.yaml"
         serviceUrls:
           ethstats: https://ethstats.mainnet.ethpandaops.io
@@ -41,7 +42,8 @@ discovery:
       - name: sepolia
         description: Smaller testnet for application development with controlled validator set.
         chainId: 11155111
-        genesisTime: 1655733600
+        genesisTime: 1655647200
+        genesisDelay: 86400
         configUrl: "https://raw.githubusercontent.com/eth-clients/sepolia/refs/heads/main/metadata/config.yaml"
         serviceUrls:
           dora: https://dora.sepolia.ethpandaops.io
@@ -77,7 +79,8 @@ discovery:
       - name: holesky
         description: Long-term public testnet designed for staking/validator testing with high validator counts.
         chainId: 17000
-        genesisTime: 1695902400
+        genesisTime: 1695902100
+        genesisDelay: 300
         configUrl: "https://raw.githubusercontent.com/eth-clients/holesky/refs/heads/main/metadata/config.yaml"
         serviceUrls:
           dora: https://dora.holesky.ethpandaops.io
@@ -113,7 +116,8 @@ discovery:
       - name: hoodi
         description: New public testnet (launched March 2025) designed for validator testing and protocol upgrades, replacing Holesky.
         chainId: 560048
-        genesisTime: 1742213400
+        genesisTime: 1742212800
+        genesisDelay: 600
         configUrl: "https://raw.githubusercontent.com/eth-clients/hoodi/refs/heads/main/metadata/config.yaml"
         serviceUrls:
           dora: https://dora.hoodi.ethpandaops.io

--- a/pkg/discovery/types.go
+++ b/pkg/discovery/types.go
@@ -57,6 +57,7 @@ type GenesisConfig struct {
 	Metadata       []ConfigFile `json:"metadata,omitempty"`
 	API            []ConfigFile `json:"api,omitempty"`
 	GenesisTime    uint64       `json:"genesisTime,omitempty"`
+	GenesisDelay   uint64       `json:"genesisDelay,omitempty"`
 }
 
 // ConfigFile represents a configuration file URL.
@@ -122,13 +123,14 @@ type GitHubRepositoryConfig struct {
 
 // StaticNetworkConfig represents the configuration for a static network.
 type StaticNetworkConfig struct {
-	Name        string            `mapstructure:"name"`
-	Description string            `mapstructure:"description"`
-	ChainID     uint64            `mapstructure:"chainId"`
-	GenesisTime uint64            `mapstructure:"genesisTime"`
-	ConfigURL   string            `mapstructure:"configUrl"`
-	ServiceURLs map[string]string `mapstructure:"serviceUrls"`
-	Forks       *ForksConfig      `mapstructure:"forks"`
+	Name         string            `mapstructure:"name"`
+	Description  string            `mapstructure:"description"`
+	ChainID      uint64            `mapstructure:"chainId"`
+	GenesisTime  uint64            `mapstructure:"genesisTime"`
+	GenesisDelay uint64            `mapstructure:"genesisDelay"`
+	ConfigURL    string            `mapstructure:"configUrl"`
+	ServiceURLs  map[string]string `mapstructure:"serviceUrls"`
+	Forks        *ForksConfig      `mapstructure:"forks"`
 }
 
 // ForksConfig represents fork configuration for both consensus and execution layers.

--- a/pkg/providers/github/network.go
+++ b/pkg/providers/github/network.go
@@ -143,18 +143,19 @@ func (p *Provider) createNetwork(ctx context.Context, config *NetworkConfig) dis
 			network.HiveURL = config.HiveURL
 		}
 
-		// Try to extract chainId and genesisTime from genesis.json
-		chainID, genesisTime, err := p.parseGenesisJSON(ctx, config.Owner, config.Repo, config.Name)
+		// Try to extract chainId, genesisTime and genesisDelay from config.yaml
+		chainID, genesisTime, genesisDelay, err := p.parseConfigYAML(ctx, config.Owner, config.Repo, config.Name)
 		if err == nil {
 			// Set the ChainID in the Network struct
 			network.ChainID = chainID
 
-			// Set the GenesisTime in the GenesisConfig struct if it exists
+			// Set the GenesisTime and GenesisDelay in the GenesisConfig struct if it exists
 			if network.GenesisConfig != nil {
 				network.GenesisConfig.GenesisTime = genesisTime
+				network.GenesisConfig.GenesisDelay = genesisDelay
 			}
 		} else {
-			p.log.WithError(err).WithField("network", config.Name).Debug("Failed to parse genesis.json")
+			p.log.WithError(err).WithField("network", config.Name).Debug("Failed to parse config.yaml")
 		}
 	}
 

--- a/pkg/providers/static/provider.go
+++ b/pkg/providers/static/provider.go
@@ -96,7 +96,8 @@ func (p *Provider) Discover(ctx context.Context, config discovery.Config) (map[s
 			}
 
 			network.GenesisConfig = &discovery.GenesisConfig{
-				GenesisTime: staticNet.GenesisTime,
+				GenesisTime:  staticNet.GenesisTime,
+				GenesisDelay: staticNet.GenesisDelay,
 				Metadata: []discovery.ConfigFile{
 					{URL: staticNet.ConfigURL, Path: u.Path},
 				},


### PR DESCRIPTION
- Added GenesisDelay field to GenesisConfig struct
- Updated GitHub provider to parse `DEPOSIT_CHAIN_ID`, `MIN_GENESIS_TIME`, and `GENESIS_DELAY` from `config.yaml`
- Updated static provider to support `genesisDelay` configuration
- Removed dependency on `genesis.json` for genesis data

**Static Network Configuration**

  | Network | Genesis Time | Genesis Delay | Config Source                                                         |
  |---------|--------------|---------------|-----------------------------------------------------------------------|
  | mainnet | 1606824000   | 604800        | https://github.com/eth-clients/mainnet/blob/main/metadata/config.yaml |
  | sepolia | 1655647200   | 86400         | https://github.com/eth-clients/sepolia/blob/main/metadata/config.yaml |
  | holesky | 1695902100   | 300           | https://github.com/eth-clients/holesky/blob/main/metadata/config.yaml |
  | hoodi   | 1742212800   | 600           | https://github.com/eth-clients/hoodi/blob/main/metadata/config.yaml   |