### PR TITLE
add cbt service for mainnet, sepolia, and hoodi

### DIFF
--- a/.github/config.production.yaml
+++ b/.github/config.production.yaml
@@ -30,6 +30,7 @@ discovery:
           forky: https://forky.mainnet.ethpandaops.io
           tracoor: https://tracoor.mainnet.ethpandaops.io
           etherscan: https://etherscan.io
+          cbt: https://cbt.mainnet.ethpandaops.io
         forks:
           consensus:
             altair:
@@ -81,6 +82,7 @@ discovery:
           forky: https://forky.sepolia.ethpandaops.io
           tracoor: https://tracoor.sepolia.ethpandaops.io
           etherscan: https://sepolia.etherscan.io
+          cbt: https://cbt.sepolia.ethpandaops.io
         forks:
           consensus:
             altair:
@@ -140,6 +142,7 @@ discovery:
           forky: https://forky.hoodi.ethpandaops.io
           tracoor: https://tracoor.hoodi.ethpandaops.io
           etherscan: https://hoodi.etherscan.io
+          cbt: https://cbt.hoodi.ethpandaops.io
         forks:
           consensus:
             altair:

--- a/pkg/discovery/types.go
+++ b/pkg/discovery/types.go
@@ -49,6 +49,7 @@ type ServiceURLs struct {
 	Forky          string `json:"forky,omitempty"`
 	Tracoor        string `json:"tracoor,omitempty"`
 	Syncoor        string `json:"syncoor,omitempty"`
+	Cbt            string `json:"cbt,omitempty"`
 }
 
 // GenesisConfig represents the configuration URLs for a network.

--- a/pkg/providers/static/provider.go
+++ b/pkg/providers/static/provider.go
@@ -74,6 +74,8 @@ func (p *Provider) Discover(ctx context.Context, config discovery.Config) (map[s
 				serviceURLs.Tracoor = value
 			case "syncoor":
 				serviceURLs.Syncoor = value
+			case "cbt":
+				serviceURLs.Cbt = value
 			}
 		}
 


### PR DESCRIPTION
Add CBT (Consensus Block Tracker) service URLs to the static network configuration for mainnet, sepolia, and hoodi networks.