### PR TITLE
feat: add configurable port overrides for helm chart parsing

### DIFF
--- a/.github/config.production.yaml
+++ b/.github/config.production.yaml
@@ -341,6 +341,10 @@ eip7870ReferenceNodes:
     - erigon
     - ethrex
 
+  # Port overrides for production (helm charts may have different defaults)
+  portOverrides:
+    wsPort: 8546  # Helm charts default to 8545, production uses 8546
+
   # Patterns to redact in output (secrets)
   secretPatterns:
     - "<path:/secrets/"

--- a/pkg/eip7870referencenodes/eip7870referencenodes.go
+++ b/pkg/eip7870referencenodes/eip7870referencenodes.go
@@ -69,8 +69,21 @@ type Config struct {
 	// SecretPatterns is a list of patterns to redact in the output.
 	SecretPatterns []string `mapstructure:"secretPatterns"`
 
+	// PortOverrides allows overriding default port values from helm charts.
+	// This is useful when production uses different ports than helm chart defaults.
+	PortOverrides PortOverrides `mapstructure:"portOverrides"`
+
 	// Storage configuration for the output file.
 	Storage StorageConfig `mapstructure:"storage"`
+}
+
+// PortOverrides contains port values to override helm chart defaults.
+type PortOverrides struct {
+	HTTPPort    int `mapstructure:"httpPort"`
+	WSPort      int `mapstructure:"wsPort"`
+	AuthPort    int `mapstructure:"authPort"`
+	MetricsPort int `mapstructure:"metricsPort"`
+	P2PPort     int `mapstructure:"p2pPort"`
 }
 
 // RepositoryConfig contains GitHub repository configuration.

--- a/pkg/eip7870referencenodes/helm_chart_parser.go
+++ b/pkg/eip7870referencenodes/helm_chart_parser.go
@@ -9,11 +9,28 @@ import (
 )
 
 // HelmChartParser parses Helm chart values.yaml files to extract base commands.
-type HelmChartParser struct{}
+type HelmChartParser struct {
+	portOverrides PortOverrides
+}
 
-// NewHelmChartParser creates a new HelmChartParser.
-func NewHelmChartParser() *HelmChartParser {
-	return &HelmChartParser{}
+// NewHelmChartParser creates a new HelmChartParser with optional port overrides.
+func NewHelmChartParser(portOverrides PortOverrides) *HelmChartParser {
+	return &HelmChartParser{
+		portOverrides: portOverrides,
+	}
+}
+
+// resolvePort returns the first non-zero value from: override, helmValue, defaultValue.
+func (p *HelmChartParser) resolvePort(override, helmValue, defaultValue int) int {
+	if override != 0 {
+		return override
+	}
+
+	if helmValue != 0 {
+		return helmValue
+	}
+
+	return defaultValue
 }
 
 // ParseBaseCommand parses a Helm chart values.yaml and extracts the base command arguments.
@@ -36,26 +53,12 @@ func (p *HelmChartParser) ParseBaseCommand(valuesYAML []byte, client string) ([]
 		}
 	}
 
-	// Set defaults if not specified
-	if values.HTTPPort == 0 {
-		values.HTTPPort = 8545
-	}
-
-	if values.WSPort == 0 {
-		values.WSPort = 8546
-	}
-
-	if values.AuthPort == 0 {
-		values.AuthPort = 8551
-	}
-
-	if values.MetricsPort == 0 {
-		values.MetricsPort = 9545
-	}
-
-	if values.P2PPort == 0 {
-		values.P2PPort = 30303
-	}
+	// Apply port overrides from config, falling back to helm chart values, then defaults
+	values.HTTPPort = p.resolvePort(p.portOverrides.HTTPPort, values.HTTPPort, 8545)
+	values.WSPort = p.resolvePort(p.portOverrides.WSPort, values.WSPort, 8546)
+	values.AuthPort = p.resolvePort(p.portOverrides.AuthPort, values.AuthPort, 8551)
+	values.MetricsPort = p.resolvePort(p.portOverrides.MetricsPort, values.MetricsPort, 9545)
+	values.P2PPort = p.resolvePort(p.portOverrides.P2PPort, values.P2PPort, 30303)
 
 	// Render the template to extract arguments
 	args := p.renderTemplate(template, values, client)

--- a/pkg/eip7870referencenodes/helm_chart_parser_test.go
+++ b/pkg/eip7870referencenodes/helm_chart_parser_test.go
@@ -71,7 +71,7 @@ defaultCommandArgsTemplate: |
 `
 
 func TestHelmChartParser_ParseBaseCommand_Reth(t *testing.T) {
-	parser := NewHelmChartParser()
+	parser := NewHelmChartParser(PortOverrides{})
 
 	args, err := parser.ParseBaseCommand([]byte(rethValuesYAML), "reth")
 	require.NoError(t, err)
@@ -145,7 +145,7 @@ defaultCommandArgsTemplate: |
 `
 
 func TestHelmChartParser_ParseBaseCommand_Geth(t *testing.T) {
-	parser := NewHelmChartParser()
+	parser := NewHelmChartParser(PortOverrides{})
 
 	args, err := parser.ParseBaseCommand([]byte(gethValuesYAML), "geth")
 	require.NoError(t, err)
@@ -177,7 +177,7 @@ func TestHelmChartParser_ParseBaseCommand_Geth(t *testing.T) {
 }
 
 func TestHelmChartParser_ParseBaseCommand_NoTemplate(t *testing.T) {
-	parser := NewHelmChartParser()
+	parser := NewHelmChartParser(PortOverrides{})
 
 	yamlWithNoTemplate := `
 httpPort: 8545
@@ -190,7 +190,7 @@ wsPort: 8546
 }
 
 func TestHelmChartParser_ParseBaseCommand_DefaultPorts(t *testing.T) {
-	parser := NewHelmChartParser()
+	parser := NewHelmChartParser(PortOverrides{})
 
 	// YAML without explicit port values - should use defaults
 	yamlWithDefaults := `
@@ -216,7 +216,7 @@ defaultCommandArgsTemplate: |
 }
 
 func TestHelmChartParser_SkipsDevnetArgs(t *testing.T) {
-	parser := NewHelmChartParser()
+	parser := NewHelmChartParser(PortOverrides{})
 
 	yamlWithDevnet := `
 defaultCommandArgsTemplate: |
@@ -239,7 +239,7 @@ defaultCommandArgsTemplate: |
 }
 
 func TestHelmChartParser_IncludesNodePortArgs(t *testing.T) {
-	parser := NewHelmChartParser()
+	parser := NewHelmChartParser(PortOverrides{})
 
 	yamlWithNodePort := `
 defaultCommandArgsTemplate: |
@@ -262,7 +262,7 @@ defaultCommandArgsTemplate: |
 }
 
 func TestHelmChartParser_FileLoggingElseBranch(t *testing.T) {
-	parser := NewHelmChartParser()
+	parser := NewHelmChartParser(PortOverrides{})
 
 	yamlWithFileLogging := `
 defaultCommandArgsTemplate: |
@@ -357,7 +357,7 @@ func TestHelmChartParser_RealRethChart(t *testing.T) {
 		t.Skip("Skipping integration test in short mode")
 	}
 
-	parser := NewHelmChartParser()
+	parser := NewHelmChartParser(PortOverrides{})
 	valuesYAML := fetchHelmChartValues(t, "reth")
 
 	args, err := parser.ParseBaseCommand(valuesYAML, "reth")
@@ -413,7 +413,7 @@ func TestHelmChartParser_RealGethChart(t *testing.T) {
 		t.Skip("Skipping integration test in short mode")
 	}
 
-	parser := NewHelmChartParser()
+	parser := NewHelmChartParser(PortOverrides{})
 	valuesYAML := fetchHelmChartValues(t, "geth")
 
 	args, err := parser.ParseBaseCommand(valuesYAML, "geth")
@@ -436,7 +436,7 @@ func TestHelmChartParser_RealNethermindChart(t *testing.T) {
 		t.Skip("Skipping integration test in short mode")
 	}
 
-	parser := NewHelmChartParser()
+	parser := NewHelmChartParser(PortOverrides{})
 	valuesYAML := fetchHelmChartValues(t, "nethermind")
 
 	args, err := parser.ParseBaseCommand(valuesYAML, "nethermind")

--- a/pkg/eip7870referencenodes/service.go
+++ b/pkg/eip7870referencenodes/service.go
@@ -39,7 +39,7 @@ func NewService(
 		httpClient: &http.Client{
 			Timeout: 30 * time.Second,
 		},
-		helmParser:     NewHelmChartParser(),
+		helmParser:     NewHelmChartParser(config.PortOverrides),
 		platformParser: NewPlatformParser(config.SecretPatterns),
 		commandBuilder: NewCommandBuilder(),
 		logger:         log.WithField("module", "eip7870_reference_nodes"),


### PR DESCRIPTION
Allow production to override helm chart default ports via new PortOverrides struct. HelmChartParser now accepts these overrides and resolves ports in order: override → helm value → default.

Production config sets wsPort to 8546 to match live environment while keeping helm chart default at 8545.