### PR TITLE
refactor(command_builder): deduplicate CLI flags across base, client …

### DIFF
--- a/pkg/eip7870referencenodes/command_builder.go
+++ b/pkg/eip7870referencenodes/command_builder.go
@@ -13,33 +13,46 @@ func NewCommandBuilder() *CommandBuilder {
 }
 
 // BuildCommand merges base args, client-specific args, and feature args into a complete command.
+// Later sources (clientSpecific, feature) override earlier sources (base).
+// Duplicate args are deduplicated, with later values taking precedence.
 func (b *CommandBuilder) BuildCommand(
 	client string,
 	baseArgs []string,
 	clientOverlay *ClientOverlay,
 	featureOverlay *FeatureOverlay,
 ) *ClientCommand {
+	var clientArgs, featureArgs []string
+
+	if clientOverlay != nil {
+		clientArgs = clientOverlay.Args
+	}
+
+	if featureOverlay != nil {
+		featureArgs = featureOverlay.Args
+	}
+
+	// Deduplicate args: later sources override earlier ones
+	// Order of precedence: feature > clientSpecific > base
+	deduped := b.deduplicateArgs(baseArgs, clientArgs, featureArgs)
+
 	cmd := &ClientCommand{
 		Client:      client,
 		DisplayName: ClientDisplayNames[client],
 		ArgsBreakdown: ArgsBreakdown{
-			Base:           baseArgs,
-			ClientSpecific: make([]string, 0),
-			Feature7870:    make([]string, 0),
+			Base:           deduped.base,
+			ClientSpecific: deduped.clientSpecific,
+			Feature7870:    deduped.feature,
 		},
 		EnvVars: make(map[string]string),
 	}
 
-	// Set client-specific args
+	// Set image from client overlay
 	if clientOverlay != nil {
-		cmd.ArgsBreakdown.ClientSpecific = clientOverlay.Args
 		cmd.Image = clientOverlay.Image
 	}
 
-	// Set feature args and env vars
+	// Set env vars and image override from feature overlay
 	if featureOverlay != nil {
-		cmd.ArgsBreakdown.Feature7870 = featureOverlay.Args
-
 		for k, v := range featureOverlay.EnvVars {
 			cmd.EnvVars[k] = v
 		}
@@ -65,6 +78,105 @@ func (b *CommandBuilder) BuildCommand(
 	}
 
 	return cmd
+}
+
+// dedupedArgs holds the deduplicated args for each source.
+type dedupedArgs struct {
+	base           []string
+	clientSpecific []string
+	feature        []string
+}
+
+// deduplicateArgs removes duplicate args across sources.
+// Later sources override earlier ones. Args are identified by their flag name.
+func (b *CommandBuilder) deduplicateArgs(base, clientSpecific, feature []string) dedupedArgs {
+	// Build a set of flag names from higher-priority sources
+	clientFlags := make(map[string]bool, len(clientSpecific))
+	for _, arg := range clientSpecific {
+		clientFlags[extractFlagName(arg)] = true
+	}
+
+	featureFlags := make(map[string]bool, len(feature))
+	for _, arg := range feature {
+		featureFlags[extractFlagName(arg)] = true
+	}
+
+	// Filter base args: remove any that are overridden by clientSpecific or feature
+	filteredBase := make([]string, 0, len(base))
+	seenBaseFlags := make(map[string]bool, len(base))
+
+	for _, arg := range base {
+		flagName := extractFlagName(arg)
+
+		// Skip if overridden by higher priority source
+		if clientFlags[flagName] || featureFlags[flagName] {
+			continue
+		}
+
+		// Skip duplicates within base
+		if seenBaseFlags[flagName] {
+			continue
+		}
+
+		seenBaseFlags[flagName] = true
+
+		filteredBase = append(filteredBase, arg)
+	}
+
+	// Filter clientSpecific args: remove any that are overridden by feature, and deduplicate
+	filteredClient := make([]string, 0, len(clientSpecific))
+	seenClientFlags := make(map[string]bool, len(clientSpecific))
+
+	for _, arg := range clientSpecific {
+		flagName := extractFlagName(arg)
+
+		// Skip if overridden by feature
+		if featureFlags[flagName] {
+			continue
+		}
+
+		// Skip duplicates within clientSpecific
+		if seenClientFlags[flagName] {
+			continue
+		}
+
+		seenClientFlags[flagName] = true
+
+		filteredClient = append(filteredClient, arg)
+	}
+
+	// Deduplicate feature args
+	filteredFeature := make([]string, 0, len(feature))
+	seenFeatureFlags := make(map[string]bool, len(feature))
+
+	for _, arg := range feature {
+		flagName := extractFlagName(arg)
+
+		if seenFeatureFlags[flagName] {
+			continue
+		}
+
+		seenFeatureFlags[flagName] = true
+
+		filteredFeature = append(filteredFeature, arg)
+	}
+
+	return dedupedArgs{
+		base:           filteredBase,
+		clientSpecific: filteredClient,
+		feature:        filteredFeature,
+	}
+}
+
+// extractFlagName extracts the flag name from an argument.
+// e.g., "--http" -> "--http", "--http.port=8545" -> "--http.port", "--http=false" -> "--http".
+func extractFlagName(arg string) string {
+	// Find the position of '=' if present
+	if idx := strings.Index(arg, "="); idx != -1 {
+		return arg[:idx]
+	}
+
+	return arg
 }
 
 // buildCommandString creates the complete command string from args breakdown.

--- a/pkg/eip7870referencenodes/command_builder_test.go
+++ b/pkg/eip7870referencenodes/command_builder_test.go
@@ -1,0 +1,132 @@
+package eip7870referencenodes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCommandBuilder_DeduplicateArgs(t *testing.T) {
+	builder := NewCommandBuilder()
+
+	tests := []struct {
+		name           string
+		base           []string
+		clientSpecific []string
+		feature        []string
+		expectedBase   []string
+		expectedClient []string
+		expectedFeat   []string
+	}{
+		{
+			name: "clientSpecific overrides base flag with different value",
+			base: []string{
+				"--http",
+				"--http.addr=0.0.0.0",
+				"--http.port=8545",
+			},
+			clientSpecific: []string{
+				"--http=false",
+			},
+			feature:        []string{},
+			expectedBase:   []string{"--http.addr=0.0.0.0", "--http.port=8545"},
+			expectedClient: []string{"--http=false"},
+			expectedFeat:   []string{},
+		},
+		{
+			name: "removes duplicates within clientSpecific",
+			base: []string{
+				"--datadir=/data",
+			},
+			clientSpecific: []string{
+				"--externalcl",
+				"--http.vhosts=*",
+				"--externalcl", // duplicate
+			},
+			feature:        []string{},
+			expectedBase:   []string{"--datadir=/data"},
+			expectedClient: []string{"--externalcl", "--http.vhosts=*"},
+			expectedFeat:   []string{},
+		},
+		{
+			name: "clientSpecific overrides base with same flag name",
+			base: []string{
+				"--http.api=eth,web3",
+				"--http.vhosts=localhost",
+			},
+			clientSpecific: []string{
+				"--http.api=admin,debug,eth",
+				"--http.vhosts=*",
+			},
+			feature:        []string{},
+			expectedBase:   []string{},
+			expectedClient: []string{"--http.api=admin,debug,eth", "--http.vhosts=*"},
+			expectedFeat:   []string{},
+		},
+		{
+			name: "feature overrides both base and clientSpecific",
+			base: []string{
+				"--metrics.port=9545",
+			},
+			clientSpecific: []string{
+				"--metrics.port=6060",
+			},
+			feature: []string{
+				"--metrics.port=9001",
+			},
+			expectedBase:   []string{},
+			expectedClient: []string{},
+			expectedFeat:   []string{"--metrics.port=9001"},
+		},
+		{
+			name: "erigon-like scenario",
+			base: []string{
+				"--datadir=/data",
+				"--http",
+				"--http.addr=0.0.0.0",
+				"--http.port=8545",
+				"--http.vhosts=*",
+				"--http.api=eth,erigon,web3",
+				"--externalcl",
+			},
+			clientSpecific: []string{
+				"--externalcl",
+				"--http.vhosts=*",
+				"--http.api=admin,debug,eth,net",
+			},
+			feature:        []string{},
+			expectedBase:   []string{"--datadir=/data", "--http", "--http.addr=0.0.0.0", "--http.port=8545"},
+			expectedClient: []string{"--externalcl", "--http.vhosts=*", "--http.api=admin,debug,eth,net"},
+			expectedFeat:   []string{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := builder.deduplicateArgs(tc.base, tc.clientSpecific, tc.feature)
+			assert.Equal(t, tc.expectedBase, result.base, "base args mismatch")
+			assert.Equal(t, tc.expectedClient, result.clientSpecific, "clientSpecific args mismatch")
+			assert.Equal(t, tc.expectedFeat, result.feature, "feature args mismatch")
+		})
+	}
+}
+
+func TestExtractFlagName(t *testing.T) {
+	tests := []struct {
+		arg      string
+		expected string
+	}{
+		{"--http", "--http"},
+		{"--http=false", "--http"},
+		{"--http.port=8545", "--http.port"},
+		{"--http.api=eth,web3,debug", "--http.api"},
+		{"--datadir=/data", "--datadir"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.arg, func(t *testing.T) {
+			result := extractFlagName(tc.arg)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
…and feature overlays

- Introduce deduplicateArgs to merge and deduplicate flags with precedence: feature > client > base.
- Store final, deduplicated slices in ArgsBreakdown instead of raw overlays.
- Add extractFlagName helper to identify flags regardless of value.
- Add comprehensive unit tests covering override and deduplication scenarios.