### PR TITLE
feat: add timestamps to forks and blob schedule

### DIFF
--- a/.github/config.production.yaml
+++ b/.github/config.production.yaml
@@ -61,6 +61,52 @@ discovery:
                 prysm: "7.0.0"
                 teku: "25.11.0"
                 tysm: "0.49.0"
+          execution:
+            frontier:
+              block: 0
+              timestamp: 1438269973
+            homestead:
+              block: 1150000
+              timestamp: 1457981393
+            dao:
+              block: 1920000
+              timestamp: 1469020840
+            tangerine_whistle:
+              block: 2463000
+              timestamp: 1476796771
+            spurious_dragon:
+              block: 2675000
+              timestamp: 1479831344
+            byzantium:
+              block: 4370000
+              timestamp: 1508131331
+            constantinople:
+              block: 7280000
+              timestamp: 1551383524
+            petersburg:
+              block: 7280000
+              timestamp: 1551383524
+            istanbul:
+              block: 9069000
+              timestamp: 1575764709
+            muir_glacier:
+              block: 9200000
+              timestamp: 1577953849
+            berlin:
+              block: 12244000
+              timestamp: 1618481223
+            london:
+              block: 12965000
+              timestamp: 1628166822
+            arrow_glacier:
+              block: 13773000
+              timestamp: 1639079723
+            gray_glacier:
+              block: 15050000
+              timestamp: 1656586444
+            paris:
+              block: 15537394
+              timestamp: 1663224179
         blobSchedule:
         - epoch: 412672
           maxBlobsPerBlock: 15

--- a/pkg/discovery/types.go
+++ b/pkg/discovery/types.go
@@ -139,13 +139,21 @@ type StaticNetworkConfig struct {
 
 // ForksConfig represents fork configuration for both consensus and execution layers.
 type ForksConfig struct {
-	Consensus map[string]ForkConfig `json:"consensus" mapstructure:"consensus"`
+	Consensus map[string]ConsensusForkConfig `json:"consensus,omitempty" mapstructure:"consensus"`
+	Execution map[string]ExecutionForkConfig `json:"execution,omitempty" mapstructure:"execution"`
 }
 
-// ForkConfig represents configuration for a specific fork.
-type ForkConfig struct {
+// ConsensusForkConfig represents configuration for a specific consensus layer fork.
+type ConsensusForkConfig struct {
 	Epoch             uint64            `json:"epoch" mapstructure:"epoch"`
+	Timestamp         uint64            `json:"timestamp,omitempty" mapstructure:"timestamp"`
 	MinClientVersions map[string]string `json:"minClientVersions,omitempty" mapstructure:"minClientVersions"`
+}
+
+// ExecutionForkConfig represents configuration for a specific execution layer fork.
+type ExecutionForkConfig struct {
+	Block     uint64 `json:"block" mapstructure:"block"`
+	Timestamp uint64 `json:"timestamp,omitempty" mapstructure:"timestamp"`
 }
 
 // Config represents the configuration for the discovery service.
@@ -194,5 +202,6 @@ type ToolImage struct {
 // BlobSchedule represents a blob capacity increase at a specific epoch.
 type BlobSchedule struct {
 	Epoch            uint64 `json:"epoch" mapstructure:"epoch"`
+	Timestamp        uint64 `json:"timestamp,omitempty" mapstructure:"timestamp"`
 	MaxBlobsPerBlock uint64 `json:"maxBlobsPerBlock" mapstructure:"maxBlobsPerBlock"`
 }

--- a/pkg/providers/github/genesis.go
+++ b/pkg/providers/github/genesis.go
@@ -11,6 +11,13 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// chainTiming holds timing parameters needed for timestamp calculations.
+type chainTiming struct {
+	genesisTime         uint64
+	slotsPerEpoch       uint64
+	slotDurationSeconds uint64
+}
+
 // parseConfigYAML extracts chainId, genesisTime, genesisDelay, fork epochs and blob schedule from config.yaml file.
 func (p *Provider) parseConfigYAML(
 	ctx context.Context,
@@ -106,20 +113,61 @@ func (p *Provider) parseConfigYAML(
 		}
 	}
 
-	// Extract fork epochs
-	forks = p.extractForkEpochs(configData, networkName)
+	// Extract timing parameters from config.
+	// NOTE: Currently assumes slot duration and slots per epoch are constant across all forks.
+	// If future forks change these values (e.g., 12s -> 6s slots), timestamp calculation
+	// will need to be updated to sum segments with different timing parameters per epoch range.
+	timing := chainTiming{
+		genesisTime:         genesisTime,
+		slotsPerEpoch:       p.extractSlotsPerEpoch(configData, networkName),
+		slotDurationSeconds: p.extractSlotDurationSeconds(configData, networkName),
+	}
+
+	// Extract consensus forks (with timestamp calculation)
+	forks = p.extractConsensusForks(configData, networkName, timing)
 
 	// Extract blob schedule
-	blobSchedule = p.extractBlobSchedule(configData, networkName)
+	blobSchedule = p.extractBlobSchedule(configData, networkName, timing)
 
 	return chainID, genesisTime, genesisDelay, forks, blobSchedule, nil
 }
 
-// extractForkEpochs extracts fork epochs from the config data.
-func (p *Provider) extractForkEpochs(configData map[string]interface{}, networkName string) *discovery.ForksConfig {
+// extractSlotsPerEpoch extracts slots per epoch from config, defaulting to 32 (mainnet preset).
+func (p *Provider) extractSlotsPerEpoch(configData map[string]interface{}, networkName string) uint64 {
+	const defaultSlotsPerEpoch = 32
+
+	if val, ok := configData["SLOTS_PER_EPOCH"]; ok {
+		if spe, ok := p.parseUint64Value(val, networkName, "SLOTS_PER_EPOCH"); ok {
+			return spe
+		}
+	}
+
+	return defaultSlotsPerEpoch
+}
+
+// extractSlotDurationSeconds extracts slot duration from config in seconds.
+func (p *Provider) extractSlotDurationSeconds(configData map[string]interface{}, networkName string) uint64 {
+	const defaultSlotDurationSeconds = 12
+
+	// Use SLOT_DURATION_MS (SECONDS_PER_SLOT is deprecated)
+	if val, ok := configData["SLOT_DURATION_MS"]; ok {
+		if ms, ok := p.parseUint64Value(val, networkName, "SLOT_DURATION_MS"); ok {
+			return ms / 1000
+		}
+	}
+
+	return defaultSlotDurationSeconds
+}
+
+// extractConsensusForks extracts consensus fork configurations from the config data and calculates timestamps.
+func (p *Provider) extractConsensusForks(
+	configData map[string]interface{},
+	networkName string,
+	timing chainTiming,
+) *discovery.ForksConfig {
 	const farFutureEpoch = uint64(18446744073709551615)
 
-	consensusForks := make(map[string]discovery.ForkConfig)
+	consensusForks := make(map[string]discovery.ConsensusForkConfig)
 
 	for key, value := range configData {
 		// Look for keys ending with _FORK_EPOCH (case-insensitive)
@@ -145,9 +193,13 @@ func (p *Provider) extractForkEpochs(configData map[string]interface{}, networkN
 			continue
 		}
 
+		// Calculate timestamp from epoch
+		timestamp := timing.genesisTime + (epoch * timing.slotsPerEpoch * timing.slotDurationSeconds)
+
 		// Add to consensus forks
-		consensusForks[forkName] = discovery.ForkConfig{
-			Epoch: epoch,
+		consensusForks[forkName] = discovery.ConsensusForkConfig{
+			Epoch:     epoch,
+			Timestamp: timestamp,
 		}
 	}
 
@@ -198,8 +250,12 @@ func (p *Provider) parseEpochValue(value interface{}, networkName, forkName stri
 	}
 }
 
-// extractBlobSchedule extracts blob schedule from the config data.
-func (p *Provider) extractBlobSchedule(configData map[string]interface{}, networkName string) []discovery.BlobSchedule {
+// extractBlobSchedule extracts blob schedule from the config data and calculates timestamps.
+func (p *Provider) extractBlobSchedule(
+	configData map[string]interface{},
+	networkName string,
+	timing chainTiming,
+) []discovery.BlobSchedule {
 	// Look for BLOB_SCHEDULE key
 	blobScheduleVal, ok := configData["BLOB_SCHEDULE"]
 	if !ok {
@@ -250,8 +306,12 @@ func (p *Provider) extractBlobSchedule(configData map[string]interface{}, networ
 			continue
 		}
 
+		// Calculate timestamp from epoch
+		timestamp := timing.genesisTime + (epoch * timing.slotsPerEpoch * timing.slotDurationSeconds)
+
 		blobSchedule = append(blobSchedule, discovery.BlobSchedule{
 			Epoch:            epoch,
+			Timestamp:        timestamp,
 			MaxBlobsPerBlock: maxBlobs,
 		})
 	}

--- a/pkg/providers/github/genesis_test.go
+++ b/pkg/providers/github/genesis_test.go
@@ -9,6 +9,13 @@ import (
 )
 
 func TestExtractBlobSchedule(t *testing.T) {
+	// Test timing parameters
+	testTiming := chainTiming{
+		genesisTime:         1000,
+		slotsPerEpoch:       32,
+		slotDurationSeconds: 12,
+	}
+
 	tests := []struct {
 		name        string
 		configData  map[string]interface{}
@@ -30,8 +37,8 @@ func TestExtractBlobSchedule(t *testing.T) {
 				},
 			},
 			expected: []discovery.BlobSchedule{
-				{Epoch: 412672, MaxBlobsPerBlock: 15},
-				{Epoch: 419072, MaxBlobsPerBlock: 21},
+				{Epoch: 412672, Timestamp: testTiming.genesisTime + (412672 * testTiming.slotsPerEpoch * testTiming.slotDurationSeconds), MaxBlobsPerBlock: 15},
+				{Epoch: 419072, Timestamp: testTiming.genesisTime + (419072 * testTiming.slotsPerEpoch * testTiming.slotDurationSeconds), MaxBlobsPerBlock: 21},
 			},
 			expectEmpty: false,
 		},
@@ -46,7 +53,7 @@ func TestExtractBlobSchedule(t *testing.T) {
 				},
 			},
 			expected: []discovery.BlobSchedule{
-				{Epoch: 412672, MaxBlobsPerBlock: 15},
+				{Epoch: 412672, Timestamp: testTiming.genesisTime + (412672 * testTiming.slotsPerEpoch * testTiming.slotDurationSeconds), MaxBlobsPerBlock: 15},
 			},
 			expectEmpty: false,
 		},
@@ -100,7 +107,7 @@ func TestExtractBlobSchedule(t *testing.T) {
 				log: log,
 			}
 
-			result := p.extractBlobSchedule(tt.configData, "test-network")
+			result := p.extractBlobSchedule(tt.configData, "test-network", testTiming)
 
 			if tt.expectEmpty {
 				assert.Nil(t, result, "Expected nil blob schedule")
@@ -110,6 +117,7 @@ func TestExtractBlobSchedule(t *testing.T) {
 
 				for i, expected := range tt.expected {
 					assert.Equal(t, expected.Epoch, result[i].Epoch, "Epoch mismatch at index %d", i)
+					assert.Equal(t, expected.Timestamp, result[i].Timestamp, "Timestamp mismatch at index %d", i)
 					assert.Equal(t, expected.MaxBlobsPerBlock, result[i].MaxBlobsPerBlock, "MaxBlobsPerBlock mismatch at index %d", i)
 				}
 			}

--- a/pkg/providers/static/provider_test.go
+++ b/pkg/providers/static/provider_test.go
@@ -58,7 +58,7 @@ func TestCombinedProviders(t *testing.T) {
 				"tracoor":     "https://tracoor.mainnet.ethpandaops.io",
 			},
 			Forks: &discovery.ForksConfig{
-				Consensus: map[string]discovery.ForkConfig{
+				Consensus: map[string]discovery.ConsensusForkConfig{
 					"electra": {
 						Epoch: 364032,
 						MinClientVersions: map[string]string{
@@ -184,7 +184,7 @@ func TestProvider_DiscoverWithForks(t *testing.T) {
 					"ethstats": "https://ethstats.test.io",
 				},
 				Forks: &discovery.ForksConfig{
-					Consensus: map[string]discovery.ForkConfig{
+					Consensus: map[string]discovery.ConsensusForkConfig{
 						"electra": {
 							Epoch: 364032,
 							MinClientVersions: map[string]string{
@@ -249,7 +249,7 @@ func TestProvider_DiscoverWithForks(t *testing.T) {
 					"ethstats": "https://ethstats.test.io",
 				},
 				Forks: &discovery.ForksConfig{
-					Consensus: map[string]discovery.ForkConfig{
+					Consensus: map[string]discovery.ConsensusForkConfig{
 						"electra": {
 							Epoch: 0,
 							// No MinClientVersions - this is valid for future/unknown requirements
@@ -285,7 +285,7 @@ func TestProvider_DiscoverWithForks(t *testing.T) {
 					"ethstats": "https://ethstats.test.io",
 				},
 				Forks: &discovery.ForksConfig{
-					Consensus: map[string]discovery.ForkConfig{
+					Consensus: map[string]discovery.ConsensusForkConfig{
 						"electra": {
 							Epoch: 100,
 							MinClientVersions: map[string]string{


### PR DESCRIPTION
- Add Timestamp field to ConsensusForkConfig and BlobSchedule structs
- Rename ForkConfig to ConsensusForkConfig for consistency
- Add ExecutionForkConfig with Block and Timestamp fields
- Add execution forks support to ForksConfig
- Create chainTiming struct to encapsulate timing parameters
- Calculate timestamps automatically from epochs using genesis time, slots per epoch, and slot duration
- Add mainnet historical execution forks to production config
- Add note about future timing changes if slot duration changes per fork