### PR TITLE
feat(discovery/clients): add ethrex to default execution clients

### DIFF
--- a/pkg/discovery/clients.go
+++ b/pkg/discovery/clients.go
@@ -26,6 +26,7 @@ const (
 	ELReth       = "reth"
 	ELErigon     = "erigon"
 	ELEthereumJS = "ethereumjs"
+	ELEthrex     = "ethrex"
 )
 
 const (
@@ -36,7 +37,7 @@ const (
 var (
 	// Buckets of known clients.
 	CLClients = []string{CLLighthouse, CLPrysm, CLLodestar, CLNimbus, CLTeku, CLGrandine}
-	ELClients = []string{ELNethermind, ELNimbusel, ELBesu, ELGeth, ELReth, ELErigon, ELEthereumJS}
+	ELClients = []string{ELNethermind, ELNimbusel, ELBesu, ELGeth, ELReth, ELErigon, ELEthereumJS, ELEthrex}
 
 	// DefaultDisplayNames maps clients to their default display names.
 	DefaultDisplayNames = map[string]string{
@@ -53,6 +54,7 @@ var (
 		ELReth:       "Reth",
 		ELErigon:     "Erigon",
 		ELEthereumJS: "EthereumJS",
+		ELEthrex:     "Ethrex",
 	}
 
 	// DefaultRepositories maps clients to their default source repositories.
@@ -70,6 +72,7 @@ var (
 		ELReth:       "paradigmxyz/reth",
 		ELErigon:     "erigontech/erigon",
 		ELEthereumJS: "ethereumjs/ethereumjs-monorepo",
+		ELEthrex:     "lambdaclass/ethrex",
 	}
 
 	// DefaultBranches maps clients to their default branches.
@@ -87,6 +90,7 @@ var (
 		ELReth:       "main",
 		ELErigon:     "main",
 		ELEthereumJS: "master",
+		ELEthrex:     "main",
 	}
 
 	DefaultWebsiteURLs = map[string]string{
@@ -103,6 +107,7 @@ var (
 		ELReth:       "https://www.paradigm.xyz/",
 		ELErigon:     "https://erigon.tech/",
 		ELEthereumJS: "https://ethereumjs.github.io/",
+		ELEthrex:     "https://ethrex.xyz/",
 	}
 
 	DefaultDocsURLs = map[string]string{
@@ -119,6 +124,7 @@ var (
 		ELReth:       "https://reth.rs/",
 		ELErigon:     "https://docs.erigon.tech/",
 		ELEthereumJS: "https://ethereumjs.readthedocs.io/",
+		ELEthrex:     "https://docs.ethrex.xyz/",
 	}
 )
 


### PR DESCRIPTION
## Summary
- Register `ethrex` (lambdaclass/ethrex, default branch `main`) alongside the other EL clients in `pkg/discovery/clients.go`. `DiscoverClients` iterates over `CLClients ++ ELClients`, so ethrex was previously absent from the top-level `clients` map in the published `networks.json`.
- ethrex was already referenced in `.github/config.production.yaml` (#66) and in `pkg/eip7870referencenodes/eip7870referencenodes.go`, but the discovery defaults (display name, repo, branch, website, docs) hadn't been added — this PR closes that gap.

## Why
Downstream consumers (e.g. panda-pulse's `/build client-el` command) read the published `clients` map to drive UIs and RPCs. Without an entry here, ethrex doesn't appear as a known execution client even though the rest of the platform supports it.

## Defaults added
| field | value |
| --- | --- |
| repository | `lambdaclass/ethrex` |
| branch | `main` |
| display name | `Ethrex` |
| website | `https://ethrex.xyz/` |
| docs | `https://docs.ethrex.xyz/` |

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./pkg/discovery/...`
- [ ] After merge: confirm next `networks.json` build emits an `ethrex` entry under `clients` with `type: execution`