### PR TITLE
feat(config.production.yaml): add ethpandaops/glamsterdam-devnets repository to discovery

### DIFF
--- a/.github/config.production.yaml
+++ b/.github/config.production.yaml
@@ -241,6 +241,11 @@ discovery:
   github:
     # List of repositories to check for networks
     repositories:
+      - name: ethpandaops/glamsterdam-devnets
+        namePrefix: glamsterdam-
+        displayName: Glamsterdam Devnets
+        description: "Glamsterdam is the planned Ethereum hard fork following Fusaka, focused on scaling the L1 and improving UX with EIPs spanning execution, consensus, and protocol-level changes."
+        image: https://ethpandaops.io/img/glamsterdam.jpg
       - name: ethpandaops/blob-devnets
         namePrefix: blob-
         displayName: Blob Devnets

--- a/.github/config.production.yaml
+++ b/.github/config.production.yaml
@@ -245,7 +245,7 @@ discovery:
         namePrefix: glamsterdam-
         displayName: Glamsterdam Devnets
         description: "Glamsterdam is the planned Ethereum hard fork following Fusaka, focused on scaling the L1 and improving UX with EIPs spanning execution, consensus, and protocol-level changes."
-        image: https://ethpandaops.io/img/glamsterdam.jpg
+        image: https://ethpandaops.io/img/bal.jpg
       - name: ethpandaops/blob-devnets
         namePrefix: blob-
         displayName: Blob Devnets


### PR DESCRIPTION
## Summary
- Adds `ethpandaops/glamsterdam-devnets` to the GitHub discovery repositories with `glamsterdam-` name prefix.

## Test plan
- [ ] Verify discovery picks up networks from the new repository after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)