### PR TITLE
fix(github): assign validated forky URLs to discovered networks

### DIFF
--- a/pkg/providers/github/services.go
+++ b/pkg/providers/github/services.go
@@ -157,6 +157,8 @@ func (p *Provider) getServiceURLs(ctx context.Context, domain string) *discovery
 				services.Explorer = result.url
 			case "forkmon":
 				services.Forkmon = result.url
+			case "forky":
+				services.Forky = result.url
 			case "assertoor":
 				services.Assertoor = result.url
 			case "dora":


### PR DESCRIPTION
The github provider probes `https://forky.<domain>` for every discovered network (`forky` is in `servicePatterns`), but the result-collection switch never assigns it, so the validated URL is dropped. Only statically configured networks (mainnet/sepolia/hoodi) currently publish a forky URL in `networks.json`. This adds the missing `case "forky"` so devnets with a responding forky instance get `serviceUrls.forky` automatically.