### PR TITLE
fix(discovery): fail run when a provider errors instead of publishing a partial result

### DIFF
--- a/pkg/discovery/service.go
+++ b/pkg/discovery/service.go
@@ -2,6 +2,7 @@ package discovery
 
 import (
 	"context"
+	"fmt"
 	"maps"
 	"strings"
 	"sync"
@@ -227,8 +228,9 @@ func (s *Service) executeDiscovery(ctx context.Context) (Result, error) {
 
 	// Collect results
 	var (
-		allNetworks = make(map[string]Network)
-		provInfos   = make([]ProviderInfo, 0)
+		allNetworks     = make(map[string]Network)
+		provInfos       = make([]ProviderInfo, 0)
+		failedProviders = make([]string, 0)
 	)
 
 	// Wait for all provider goroutines to complete
@@ -241,13 +243,32 @@ func (s *Service) executeDiscovery(ctx context.Context) (Result, error) {
 				Clients:         make(map[string]ClientInfo),
 			}, ctx.Err()
 		case pr := <-resultCh:
-			if pr.err == nil && pr.networks != nil {
+			if pr.err != nil {
+				failedProviders = append(failedProviders, pr.provider.Name())
+
+				continue
+			}
+
+			if pr.networks != nil {
 				// Merge networks, newer ones will overwrite older ones with the same key
 				maps.Copy(allNetworks, pr.networks)
 
 				provInfos = append(provInfos, ProviderInfo{Name: pr.provider.Name()})
 			}
 		}
+	}
+
+	// If any provider failed, the aggregated set is incomplete. Presenting it as a
+	// successful result would let callers publish a partial networks.json that
+	// silently drops the failed provider's networks. Fail the run instead so the
+	// previously published data is preserved.
+	if len(failedProviders) > 0 {
+		return Result{
+				Networks:        make(map[string]Network),
+				NetworkMetadata: make(map[string]RepositoryMetadata),
+				Clients:         make(map[string]ClientInfo),
+			}, fmt.Errorf("discovery incomplete: %d of %d providers failed (%s)",
+				len(failedProviders), len(providers), strings.Join(failedProviders, ", "))
 	}
 
 	// Build repository metadata from config

--- a/pkg/discovery/service_test.go
+++ b/pkg/discovery/service_test.go
@@ -2,6 +2,7 @@ package discovery
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -174,4 +175,51 @@ func TestDiscoveryService_NoProviders(t *testing.T) {
 	// Stop service - we'll skip this part to avoid the context deadline errors
 	// Just cancel the main context instead
 	cancel()
+}
+
+// TestRunOnce_PartialProviderFailure verifies that when one provider fails, the
+// run returns an error and does not hand back a partial result. Publishing a
+// partial set would silently drop the failed provider's networks.
+func TestRunOnce_PartialProviderFailure(t *testing.T) {
+	log := logrus.New()
+	log.SetLevel(logrus.PanicLevel)
+
+	service, err := NewService(log, Config{}, nil)
+	require.NoError(t, err)
+
+	// One provider fails transiently, the other succeeds.
+	service.RegisterProvider(NewMockProvider("failing", nil, errors.New("upstream unavailable")))
+	service.RegisterProvider(NewMockProvider("static", map[string]Network{
+		"mainnet": {Name: "mainnet", Status: "active"},
+	}, nil))
+
+	result, err := service.RunOnce(context.Background())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failing")
+	assert.Empty(t, result.Networks, "a partial result must not be returned when a provider fails")
+}
+
+// TestRunOnce_AllProvidersSucceed verifies the happy path still returns the
+// merged result with no error.
+func TestRunOnce_AllProvidersSucceed(t *testing.T) {
+	log := logrus.New()
+	log.SetLevel(logrus.PanicLevel)
+
+	service, err := NewService(log, Config{}, nil)
+	require.NoError(t, err)
+
+	service.RegisterProvider(NewMockProvider("static", map[string]Network{
+		"mainnet": {Name: "mainnet", Status: "active"},
+	}, nil))
+	service.RegisterProvider(NewMockProvider("github", map[string]Network{
+		"devnet-1": {Name: "devnet-1", Status: "active"},
+	}, nil))
+
+	result, err := service.RunOnce(context.Background())
+
+	require.NoError(t, err)
+	assert.Len(t, result.Networks, 2)
+	assert.Contains(t, result.Networks, "mainnet")
+	assert.Contains(t, result.Networks, "devnet-1")
 }


### PR DESCRIPTION
When one discovery provider fails, its error was dropped and the incomplete network set was returned as a successful result. Callers then overwrite networks.json with a partial set, silently removing every network that the failed provider would have supplied. Downstream consumers read those missing networks as deleted.

## Change

`executeDiscovery` now records any provider that returns an error and fails the run when one or more providers failed, instead of returning a partial result with a nil error. A failed run is skipped by the caller, so the previously published data is preserved. The happy path where all providers succeed is unchanged.

## Tests

- `TestRunOnce_PartialProviderFailure`: one failing and one succeeding provider now yields an error and an empty result, so no partial data is published.
- `TestRunOnce_AllProvidersSucceed`: guards that the normal merge path still returns all networks with no error.

All package tests pass and the linter reports no issues.