### PR TITLE
fix(github): only mark a network active or inactive on a 200 response

### DIFF
--- a/pkg/providers/github/status.go
+++ b/pkg/providers/github/status.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"net/http"
 	"path"
 
 	"github.com/ethpandaops/cartographoor/pkg/discovery"
@@ -25,7 +26,7 @@ func (p *Provider) determineNetworkStatus(
 	kubePath := path.Join(kubernetesDir, networkName)
 
 	_, _, resp, err := client.Repositories.GetContents(ctx, owner, repo, kubePath, nil)
-	if err == nil || (resp != nil && resp.StatusCode != 404) {
+	if err == nil && resp != nil && resp.StatusCode == http.StatusOK {
 		status = active
 
 		// For active networks, try to get config values
@@ -35,7 +36,7 @@ func (p *Provider) determineNetworkStatus(
 		archivePath := path.Join(kubernetesArchiveDir, networkName)
 
 		_, _, resp, err := client.Repositories.GetContents(ctx, owner, repo, archivePath, nil)
-		if err == nil || (resp != nil && resp.StatusCode != 404) {
+		if err == nil && resp != nil && resp.StatusCode == http.StatusOK {
 			status = inactive
 		}
 	}

--- a/pkg/providers/github/status_test.go
+++ b/pkg/providers/github/status_test.go
@@ -1,0 +1,76 @@
+package github
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	gh "github.com/google/go-github/v53/github"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDetermineNetworkStatus covers how a network's status is derived from the
+// kubernetes and kubernetes-archive directory lookups. A network must only be
+// marked active or inactive on a positive 200 response. Any other response,
+// including a transient 403 rate limit or a 5xx outage, must leave the status
+// unknown rather than laundering the error into a false active/inactive.
+func TestDetermineNetworkStatus(t *testing.T) {
+	log := logrus.New()
+	log.SetLevel(logrus.PanicLevel)
+
+	const okBody = `[{"name":"file.yaml","type":"file"}]`
+
+	cases := []struct {
+		name          string
+		kubeStatus    int
+		archiveStatus int
+		want          string
+	}{
+		{"present in kubernetes is active", http.StatusOK, http.StatusNotFound, "active"},
+		{"present in archive is inactive", http.StatusNotFound, http.StatusOK, "inactive"},
+		{"absent in both is unknown", http.StatusNotFound, http.StatusNotFound, "unknown"},
+		{"rate limit does not imply active", http.StatusForbidden, http.StatusForbidden, "unknown"},
+		{"server error does not imply active", http.StatusInternalServerError, http.StatusInternalServerError, "unknown"},
+		{"unauthorized does not imply active", http.StatusUnauthorized, http.StatusUnauthorized, "unknown"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var code int
+
+				switch {
+				case strings.Contains(r.URL.Path, kubernetesArchiveDir):
+					code = tc.archiveStatus
+				case strings.Contains(r.URL.Path, kubernetesDir):
+					code = tc.kubeStatus
+				default:
+					// Any secondary lookups (for example config values on the
+					// active path) are not under test.
+					code = http.StatusNotFound
+				}
+
+				w.WriteHeader(code)
+
+				if code == http.StatusOK {
+					_, _ = w.Write([]byte(okBody))
+				}
+			}))
+			defer ts.Close()
+
+			provider, err := NewProvider(log, nil)
+			require.NoError(t, err)
+
+			client := gh.NewClient(&http.Client{Transport: &mockTransport{URL: ts.URL}})
+
+			status, _, _ := provider.determineNetworkStatus(
+				context.Background(), client, "ethpandaops", "devnets", "devnet-x")
+
+			assert.Equal(t, tc.want, status)
+		})
+	}
+}


### PR DESCRIPTION
determineNetworkStatus inferred directory existence from any response that was not a 404. A transient 403 rate limit, a 401 from an expired token, or a 5xx during a GitHub outage therefore stamped the network active, and the same pattern in the archive check could stamp it inactive. Because rate limiting is the most common failure mode for this service, a single throttled lookup could flip archived or removed networks to active in the published networks.json, corrupting the status field and the active/inactive counts that downstream consumers rely on.

## Change

Both the kubernetes and kubernetes-archive existence checks now require a positive 200 response before assigning active or inactive. Any other response leaves the status unknown rather than treating an error as existence. This matches checkSelfHostedDNS, which already required a 200.

## Tests

`TestDetermineNetworkStatus` covers the positive cases (200 in kubernetes is active, 200 in archive is inactive, absent in both is unknown) and the regressions (403, 500, and 401 all resolve to unknown instead of active).

All package tests pass and the linter reports no issues.