### PR TITLE
fix(validatorranges): fix inventory lookups and surface upload failures

### DIFF
--- a/pkg/validatorranges/service.go
+++ b/pkg/validatorranges/service.go
@@ -130,17 +130,10 @@ func (s *Service) fetchEthpandaopsRanges(ctx context.Context, networkName string
 		repo = "ethpandaops/ansible"
 	}
 
-	// Strip repository-specific prefixes from network name for inventory path
-	inventoryName := networkName
-	// Common prefixes to strip (e.g., "fusaka-devnet-5" -> "devnet-5")
-	prefixes := []string{"fusaka-", "pectra-", "dencun-", "eof-", "verkle-"}
-	for _, prefix := range prefixes {
-		if after, ok := strings.CutPrefix(networkName, prefix); ok {
-			inventoryName = after
-
-			break
-		}
-	}
+	// Strip the repository's own name prefix from the network name for the
+	// inventory path (e.g. repo "ethpandaops/fusaka-devnets" + network
+	// "fusaka-devnet-5" -> "devnet-5").
+	inventoryName := stripRepoPrefix(networkName, repo)
 
 	// Build inventory URLs
 	urls := s.fetcher.BuildInventoryURLs(repo, inventoryName)
@@ -174,6 +167,28 @@ func (s *Service) fetchEthpandaopsRanges(ctx context.Context, networkName string
 
 	// Aggregate all ranges from ethpandaops
 	return AggregateRanges(allRanges), nil
+}
+
+// stripRepoPrefix removes the repository's own name prefix from a network
+// name so it maps to the inventory path used inside that repository. Devnet
+// repositories follow the "<prefix>-devnets" naming convention and prefix
+// their discovered network names with "<prefix>-", e.g. repository
+// "ethpandaops/glamsterdam-devnets" produces a network named
+// "glamsterdam-devnet-7", whose inventory actually lives at
+// "ansible/inventories/devnet-7" inside that repository.
+func stripRepoPrefix(networkName, repo string) string {
+	parts := strings.Split(repo, "/")
+	if len(parts) != 2 {
+		return networkName
+	}
+
+	repoPrefix := strings.TrimSuffix(parts[1], "-devnets")
+
+	if after, ok := strings.CutPrefix(networkName, repoPrefix+"-"); ok {
+		return after
+	}
+
+	return networkName
 }
 
 // fetchAdditionalRanges fetches validator ranges from additional configured sources.

--- a/pkg/validatorranges/service.go
+++ b/pkg/validatorranges/service.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"sync"
 
 	"github.com/ethpandaops/cartographoor/pkg/discovery"
 	"github.com/ethpandaops/cartographoor/pkg/storage/s3"
@@ -37,6 +38,12 @@ func (s *Service) GenerateValidatorRanges(ctx context.Context, networks map[stri
 	// Use semaphore to limit concurrency to 5 networks at a time
 	sem := semaphore.NewWeighted(5)
 
+	var (
+		mu          sync.Mutex
+		firstErr    error
+		failedCount int
+	)
+
 	for name, network := range networks {
 		if err := sem.Acquire(ctx, 1); err != nil {
 			return fmt.Errorf("failed to acquire semaphore: %w", err)
@@ -50,6 +57,16 @@ func (s *Service) GenerateValidatorRanges(ctx context.Context, networks map[stri
 					"network": networkName,
 					"error":   err,
 				}).Error("Failed to process network")
+
+				mu.Lock()
+
+				failedCount++
+
+				if firstErr == nil {
+					firstErr = fmt.Errorf("network %s: %w", networkName, err)
+				}
+
+				mu.Unlock()
 			}
 		}(name, network)
 	}
@@ -60,6 +77,10 @@ func (s *Service) GenerateValidatorRanges(ctx context.Context, networks map[stri
 	}
 
 	sem.Release(5)
+
+	if firstErr != nil {
+		return fmt.Errorf("%d of %d networks failed to process: %w", failedCount, len(networks), firstErr)
+	}
 
 	s.logger.Info("Validator ranges generation completed")
 

--- a/pkg/validatorranges/service_test.go
+++ b/pkg/validatorranges/service_test.go
@@ -1,0 +1,58 @@
+package validatorranges
+
+import "testing"
+
+func TestStripRepoPrefix(t *testing.T) {
+	tests := []struct {
+		name        string
+		networkName string
+		repo        string
+		want        string
+	}{
+		{
+			name:        "prefix matches the repo name and is stripped",
+			networkName: "glamsterdam-devnet-7",
+			repo:        "ethpandaops/glamsterdam-devnets",
+			want:        "devnet-7",
+		},
+		{
+			name:        "another repo not in the old hardcoded list still strips correctly",
+			networkName: "peerdas-devnet-7",
+			repo:        "ethpandaops/peerdas-devnets",
+			want:        "devnet-7",
+		},
+		{
+			name:        "repo previously covered by the old hardcoded list still works",
+			networkName: "fusaka-devnet-5",
+			repo:        "ethpandaops/fusaka-devnets",
+			want:        "devnet-5",
+		},
+		{
+			name:        "network name has no matching repo prefix, left unchanged",
+			networkName: "mainnet",
+			repo:        "ethpandaops/ansible",
+			want:        "mainnet",
+		},
+		{
+			name:        "malformed repo path, left unchanged",
+			networkName: "glamsterdam-devnet-7",
+			repo:        "not-a-valid-repo-path",
+			want:        "glamsterdam-devnet-7",
+		},
+		{
+			name:        "empty repo, left unchanged",
+			networkName: "glamsterdam-devnet-7",
+			repo:        "",
+			want:        "glamsterdam-devnet-7",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := stripRepoPrefix(tt.networkName, tt.repo)
+			if got != tt.want {
+				t.Errorf("stripRepoPrefix(%q, %q) = %q, want %q", tt.networkName, tt.repo, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/validatorranges/service_test.go
+++ b/pkg/validatorranges/service_test.go
@@ -1,6 +1,16 @@
 package validatorranges
 
-import "testing"
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/ethpandaops/cartographoor/pkg/discovery"
+	"github.com/ethpandaops/cartographoor/pkg/storage/s3"
+	"github.com/sirupsen/logrus"
+)
 
 func TestStripRepoPrefix(t *testing.T) {
 	tests := []struct {
@@ -54,5 +64,89 @@ func TestStripRepoPrefix(t *testing.T) {
 				t.Errorf("stripRepoPrefix(%q, %q) = %q, want %q", tt.networkName, tt.repo, got, tt.want)
 			}
 		})
+	}
+}
+
+const testInventory = `[lighthouse_geth]
+node1 ansible_host=1.2.3.4 validator_start=0 validator_end=8
+`
+
+// TestGenerateValidatorRanges_ReturnsErrorOnUploadFailure verifies that a
+// network whose upload to S3 fails causes GenerateValidatorRanges to return
+// a non-nil error, instead of the run being reported as fully successful.
+//
+// The fetcher has no injection seam, so processNetwork also attempts a real
+// lookup against the ethpandaops fallback repository for this network. That
+// lookup fails fast (the repository does not exist) and is non-fatal by
+// design; the additional source below is what actually feeds this test.
+func TestGenerateValidatorRanges_ReturnsErrorOnUploadFailure(t *testing.T) {
+	inventorySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(testInventory))
+	}))
+	defer inventorySrv.Close()
+
+	log := logrus.New()
+
+	storage, err := s3.NewProvider(log, s3.Config{
+		BucketName:     "test-bucket",
+		Region:         "us-east-1",
+		Endpoint:       "http://127.0.0.1:1", // nothing listens here, upload always fails
+		ForcePathStyle: true,
+		AccessKey:      "x",
+		SecretKey:      "x",
+	})
+	if err != nil {
+		t.Fatalf("NewProvider: %v", err)
+	}
+
+	cfg := &Config{
+		AdditionalSources: map[string][]SourceConfig{
+			"test-network": {
+				{URL: inventorySrv.URL, Name: "test-source"},
+			},
+		},
+	}
+
+	svc := NewService(storage, cfg, log)
+
+	networks := map[string]discovery.Network{
+		"test-network": {Name: "test-network", Repository: ""},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	err = svc.GenerateValidatorRanges(ctx, networks)
+
+	if err == nil {
+		t.Fatal("expected GenerateValidatorRanges to return an error when a network fails to upload, got nil")
+	}
+}
+
+// TestGenerateValidatorRanges_NoErrorWhenNothingToUpload verifies that
+// networks with no discoverable validator ranges (the normal, expected case
+// for most networks) do not cause the run to fail.
+func TestGenerateValidatorRanges_NoErrorWhenNothingToUpload(t *testing.T) {
+	log := logrus.New()
+
+	storage, err := s3.NewProvider(log, s3.Config{
+		BucketName: "test-bucket",
+		Region:     "us-east-1",
+	})
+	if err != nil {
+		t.Fatalf("NewProvider: %v", err)
+	}
+
+	svc := NewService(storage, &Config{}, log)
+
+	networks := map[string]discovery.Network{
+		"mainnet": {Name: "mainnet", Repository: ""},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	if err := svc.GenerateValidatorRanges(ctx, networks); err != nil {
+		t.Fatalf("expected no error when a network simply has no ranges to publish, got %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- The ethpandaops-source fetch stripped a hardcoded list of repo prefixes from the network name before building the inventory URL. Any repository added after that list was written used a prefix it did not recognize, so the fetch built the wrong URL and silently found nothing. The prefix is now derived from the repository name itself, since devnet repos follow a consistent naming convention, so this keeps working without the list needing manual upkeep.
- Each network was processed in its own goroutine, and a failure there was only logged before being discarded. The job always returned success even if every single upload failed. Failures are now tracked across the goroutines and returned as an aggregated error, so a broken run is distinguishable from a working one.

## Test plan
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` reports no issues
- [x] Added unit tests covering the prefix derivation, including networks from repositories not covered by the previous hardcoded list
- [x] Added tests covering both a forced upload failure (real S3 provider pointed at an unreachable endpoint) and the normal case where a network has nothing to publish