### PR TITLE
fix(github): anchor fork and blob schedule timestamps on genesis delay

### DIFF
--- a/pkg/providers/github/genesis.go
+++ b/pkg/providers/github/genesis.go
@@ -13,6 +13,10 @@ import (
 
 // chainTiming holds timing parameters needed for timestamp calculations.
 type chainTiming struct {
+	// genesisTime is the actual beacon chain genesis anchor used to derive
+	// fork and blob schedule timestamps: MIN_GENESIS_TIME + GENESIS_DELAY.
+	// This is not the same as the raw MIN_GENESIS_TIME value stored on
+	// GenesisConfig, which is kept separate from GENESIS_DELAY there.
 	genesisTime         uint64
 	slotsPerEpoch       uint64
 	slotDurationSeconds uint64
@@ -117,8 +121,12 @@ func (p *Provider) parseConfigYAML(
 	// NOTE: Currently assumes slot duration and slots per epoch are constant across all forks.
 	// If future forks change these values (e.g., 12s -> 6s slots), timestamp calculation
 	// will need to be updated to sum segments with different timing parameters per epoch range.
+	//
+	// The beacon chain genesis anchor is MIN_GENESIS_TIME + GENESIS_DELAY, not
+	// MIN_GENESIS_TIME alone, so GENESIS_DELAY must be included here even though
+	// the two are returned and stored separately on GenesisConfig.
 	timing := chainTiming{
-		genesisTime:         genesisTime,
+		genesisTime:         genesisTime + genesisDelay,
 		slotsPerEpoch:       p.extractSlotsPerEpoch(configData, networkName),
 		slotDurationSeconds: p.extractSlotDurationSeconds(configData, networkName),
 	}

--- a/pkg/providers/github/genesis_test.go
+++ b/pkg/providers/github/genesis_test.go
@@ -1,11 +1,18 @@
 package github
 
 import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/ethpandaops/cartographoor/pkg/discovery"
+	gh "github.com/google/go-github/v53/github"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestExtractBlobSchedule(t *testing.T) {
@@ -123,4 +130,50 @@ func TestExtractBlobSchedule(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestParseConfigYAML_TimestampsIncludeGenesisDelay(t *testing.T) {
+	const configYAML = `
+MIN_GENESIS_TIME: 1000
+GENESIS_DELAY: 60
+TEST_FORK_EPOCH: 1
+SLOTS_PER_EPOCH: 32
+SLOT_DURATION_MS: 12000
+`
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/ethpandaops/example-devnets/contents/network-configs/devnet-1/metadata/config.yaml",
+		func(w http.ResponseWriter, r *http.Request) {
+			content := base64.StdEncoding.EncodeToString([]byte(configYAML))
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `{"type":"file","encoding":"base64","content":%q}`, content)
+		})
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	log := logrus.New()
+
+	provider, err := NewProvider(log, nil)
+	require.NoError(t, err)
+
+	provider.githubClient = gh.NewClient(&http.Client{Transport: &mockTransport{URL: srv.URL}})
+
+	_, genesisTime, genesisDelay, forks, _, err := provider.parseConfigYAML(
+		context.Background(), "ethpandaops", "example-devnets", "devnet-1")
+	require.NoError(t, err)
+
+	// The raw values returned for GenesisConfig must stay separate and unchanged.
+	assert.Equal(t, uint64(1000), genesisTime)
+	assert.Equal(t, uint64(60), genesisDelay)
+
+	require.NotNil(t, forks)
+
+	fork, ok := forks.Consensus["test"]
+	require.True(t, ok, "expected a 'test' fork entry")
+
+	// The derived timestamp must anchor on MIN_GENESIS_TIME + GENESIS_DELAY,
+	// not MIN_GENESIS_TIME alone.
+	wantTimestamp := uint64(1000) + uint64(60) + uint64(1)*32*12
+	assert.Equal(t, wantTimestamp, fork.Timestamp)
 }


### PR DESCRIPTION
## Summary
- Fork epoch and blob schedule timestamps were computed from MIN_GENESIS_TIME alone, even though the actual beacon chain genesis anchor is MIN_GENESIS_TIME plus GENESIS_DELAY. Every derived timestamp came out early by exactly the configured delay for any network with a non-zero value, which is the common case for these devnets.
- The anchor used for timestamp math now includes the delay. The raw genesis time and delay fields stored on GenesisConfig are unchanged, since those still describe the two config values separately rather than the combined anchor.

## Test plan
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` reports no issues
- [x] Added a test that drives config parsing through a mocked GitHub response and asserts the derived timestamp includes the delay
- [x] Confirmed the new test fails without the fix and passes with it