### PR TITLE
fix(github): guard against malformed directory entries in network-configs

### DIFF
--- a/pkg/providers/github/provider.go
+++ b/pkg/providers/github/provider.go
@@ -112,18 +112,20 @@ func (p *Provider) discoverRepositoryNetworks(
 
 	// Process directories in network-configs
 	for _, content := range dirContent {
-		if *content.Type != "dir" {
+		if content.GetType() != "dir" {
 			continue
 		}
 
+		name := content.GetName()
+
 		networkConfig := &NetworkConfig{
-			Name:         *content.Name,
-			PrefixedName: *content.Name,
+			Name:         name,
+			PrefixedName: name,
 			Repository:   repoPath,
 			Owner:        owner,
 			Repo:         repo,
-			Path:         path.Join(netConfigPath, *content.Name),
-			URL:          *content.HTMLURL,
+			Path:         path.Join(netConfigPath, name),
+			URL:          content.GetHTMLURL(),
 		}
 
 		// Apply prefix if configured

--- a/pkg/providers/github/provider_test.go
+++ b/pkg/providers/github/provider_test.go
@@ -488,3 +488,58 @@ func mockGitHubAPIWithStatus(t *testing.T) *httptest.Server {
 
 	return server
 }
+
+func TestDiscoverRepositoryNetworks_MalformedEntryDoesNotPanic(t *testing.T) {
+	mux := http.NewServeMux()
+
+	// An entry with no type, name, or html_url should be skipped rather
+	// than crash the whole discovery run.
+	mux.HandleFunc("/ethpandaops/dencun-devnets/contents/network-configs", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `[{"type":null,"name":null,"html_url":null}]`)
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	log := logrus.New()
+
+	provider, err := NewProvider(log, nil)
+	require.NoError(t, err)
+
+	provider.githubClient = gh.NewClient(&http.Client{Transport: &mockTransport{URL: server.URL}})
+
+	networks, err := provider.discoverRepositoryNetworks(context.Background(), provider.githubClient, discovery.GitHubRepositoryConfig{
+		Name: "ethpandaops/dencun-devnets",
+	})
+
+	require.NoError(t, err)
+	assert.Empty(t, networks, "an entry with no type should be skipped, not turned into a network")
+}
+
+func TestDiscoverRepositoryNetworks_WellFormedEntryStillWorks(t *testing.T) {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/ethpandaops/dencun-devnets/contents/network-configs", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `[{"type":"dir","name":"devnet-1","html_url":"https://github.com/ethpandaops/dencun-devnets/tree/master/network-configs/devnet-1"}]`)
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	log := logrus.New()
+
+	provider, err := NewProvider(log, nil)
+	require.NoError(t, err)
+
+	provider.githubClient = gh.NewClient(&http.Client{Transport: &mockTransport{URL: server.URL}})
+
+	networks, err := provider.discoverRepositoryNetworks(context.Background(), provider.githubClient, discovery.GitHubRepositoryConfig{
+		Name: "ethpandaops/dencun-devnets",
+	})
+
+	require.NoError(t, err)
+	require.Len(t, networks, 1)
+	assert.Equal(t, "devnet-1", networks["devnet-1"].Name)
+}


### PR DESCRIPTION
## Summary
- Directory entries returned from the GitHub contents API were read with raw pointer dereferences on type, name, and html_url. A single entry missing any of those fields would panic and crash the whole discovery run instead of just skipping that one entry.
- Switched to the generated accessor methods, which fall back to the zero value when a field is nil, so a malformed entry is skipped rather than taking down the process.

## Test plan
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` reports no issues
- [x] Added a test with a null-fielded entry and confirmed it no longer panics
- [x] Added a control test confirming a well-formed entry is still processed correctly
- [x] Confirmed the new test panics without the fix and passes with it