### PR TITLE
fix(inventory): cap Dora response body size

### DIFF
--- a/pkg/inventory/fetcher.go
+++ b/pkg/inventory/fetcher.go
@@ -12,6 +12,12 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// maxDoraResponseBytes bounds how much of a Dora API response body is read
+// into memory. Real client-list responses are well under a megabyte; this
+// leaves generous headroom while still capping a hung or misbehaving
+// endpoint from exhausting memory.
+const maxDoraResponseBytes = 10 * 1024 * 1024
+
 // Fetcher is responsible for fetching data from Dora APIs.
 type Fetcher struct {
 	log     *logrus.Entry
@@ -183,7 +189,7 @@ func (f *Fetcher) doFetch(ctx context.Context, url string) ([]byte, error) {
 		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
 	}
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(http.MaxBytesReader(nil, resp.Body, maxDoraResponseBytes))
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response body: %w", err)
 	}

--- a/pkg/inventory/fetcher_test.go
+++ b/pkg/inventory/fetcher_test.go
@@ -1,0 +1,49 @@
+package inventory
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDoFetch_RejectsOversizedResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+
+		buf := make([]byte, 1024)
+		for sent := 0; sent < maxDoraResponseBytes+1024; sent += len(buf) {
+			if _, err := w.Write(buf); err != nil {
+				return
+			}
+		}
+	}))
+	defer srv.Close()
+
+	f := NewFetcher(logrus.NewEntry(logrus.New()))
+
+	_, err := f.doFetch(context.Background(), srv.URL)
+
+	require.Error(t, err, "expected an oversized response to be rejected instead of fully buffered")
+}
+
+func TestDoFetch_NormalResponseStillWorks(t *testing.T) {
+	const body = `{"clients":[{"client_name":"lighthouse"}]}`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	f := NewFetcher(logrus.NewEntry(logrus.New()))
+
+	got, err := f.doFetch(context.Background(), srv.URL)
+
+	require.NoError(t, err)
+	assert.Equal(t, body, string(got))
+}


### PR DESCRIPTION
## Summary
- Dora API responses were read into memory with a plain io.ReadAll and no size limit, so a hung or misbehaving endpoint could grow the process's memory usage without bound. Real client-list responses are well under a megabyte.
- Wrapped the body in a bounded reader so a response over the cap fails cleanly instead of being fully buffered.

## Test plan
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` reports no issues
- [x] Added a test that streams an oversized response and confirms it is rejected
- [x] Added a control test confirming a normal-sized response still works
- [x] Confirmed the new test fails without the fix and passes with it