### PR TITLE
fix(storage): remove backoffJitterPercent, a config field with no effect

### DIFF
--- a/.github/config.production.yaml
+++ b/.github/config.production.yaml
@@ -437,7 +437,7 @@ storage:
   # Access control list for the uploaded file (REQUIRED for public access)
   acl: public-read
 
-  # Retry configuration
+  # Retry configuration (applies to downloads; uploads rely on the AWS SDK's
+  # own default retry behavior)
   retryDuration: 5s
   maxRetries: 3
-  backoffJitterPercent: 20

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -61,10 +61,10 @@ storage:
   # Access control list for the uploaded file (optional)
   # acl: public-read
 
-  # Retry configuration
+  # Retry configuration (applies to downloads; uploads rely on the AWS SDK's
+  # own default retry behavior)
   retryDuration: 5s
   maxRetries: 3
-  backoffJitterPercent: 20
 
 # Inventory generation configuration
 inventory:

--- a/pkg/storage/s3/provider.go
+++ b/pkg/storage/s3/provider.go
@@ -17,20 +17,23 @@ import (
 )
 
 // Config represents the configuration for the S3 storage provider.
+//
+// Retry resilience for Upload/UploadRaw comes from the AWS SDK's own
+// default retryer, not from a field here. RetryDuration and MaxRetries
+// govern only the application-level retry loop in Download.
 type Config struct {
-	BucketName           string        `mapstructure:"bucketName"`
-	Key                  string        `mapstructure:"key"`
-	Region               string        `mapstructure:"region"`
-	Endpoint             string        `mapstructure:"endpoint"`
-	AccessKey            string        `mapstructure:"accessKey"`
-	SecretKey            string        `mapstructure:"secretKey"`
-	ForcePathStyle       bool          `mapstructure:"forcePathStyle"`
-	DisableSSL           bool          `mapstructure:"disableSSL"`
-	ContentType          string        `mapstructure:"contentType"`
-	ACL                  string        `mapstructure:"acl"`
-	RetryDuration        time.Duration `mapstructure:"retryDuration"`
-	MaxRetries           int           `mapstructure:"maxRetries"`
-	BackoffJitterPercent int           `mapstructure:"backoffJitterPercent"`
+	BucketName     string        `mapstructure:"bucketName"`
+	Key            string        `mapstructure:"key"`
+	Region         string        `mapstructure:"region"`
+	Endpoint       string        `mapstructure:"endpoint"`
+	AccessKey      string        `mapstructure:"accessKey"`
+	SecretKey      string        `mapstructure:"secretKey"`
+	ForcePathStyle bool          `mapstructure:"forcePathStyle"`
+	DisableSSL     bool          `mapstructure:"disableSSL"`
+	ContentType    string        `mapstructure:"contentType"`
+	ACL            string        `mapstructure:"acl"`
+	RetryDuration  time.Duration `mapstructure:"retryDuration"`
+	MaxRetries     int           `mapstructure:"maxRetries"`
 }
 
 // Provider implements the storage provider interface for S3.
@@ -59,10 +62,6 @@ func NewProvider(log *logrus.Logger, cfg Config) (*Provider, error) {
 
 	if cfg.MaxRetries == 0 {
 		cfg.MaxRetries = 3
-	}
-
-	if cfg.BackoffJitterPercent == 0 {
-		cfg.BackoffJitterPercent = 20
 	}
 
 	return &Provider{

--- a/pkg/storage/s3/provider_test.go
+++ b/pkg/storage/s3/provider_test.go
@@ -27,5 +27,4 @@ func TestS3Provider_ConfigDefaults(t *testing.T) {
 	assert.Equal(t, "application/json", provider.config.ContentType)
 	assert.Equal(t, 5*time.Second, provider.config.RetryDuration)
 	assert.Equal(t, 3, provider.config.MaxRetries)
-	assert.Equal(t, 20, provider.config.BackoffJitterPercent)
 }


### PR DESCRIPTION
## Summary
- The backoffJitterPercent field was declared, defaulted, and asserted in a test, but never read anywhere in the retry logic. Uploads have no application-level retry at all (they rely entirely on the AWS SDK's own default retryer), and Download's retry loop uses a flat delay with no jitter. Anyone tuning this value in their config was changing nothing.
- Removed the field along with its entries in the example and production config files, and documented on the config struct where retry behavior actually comes from.

## Test plan
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` reports no issues
- [x] Updated the existing config defaults test to match the reduced config surface
- [x] Confirmed no remaining references to the field anywhere in code or config